### PR TITLE
[refactor] Security 수정 및 Entity 수정

### DIFF
--- a/src/main/java/dripnote/bean/domain/Bean.java
+++ b/src/main/java/dripnote/bean/domain/Bean.java
@@ -1,4 +1,4 @@
-package dripnote.bean.entity;
+package dripnote.bean.domain;
 
 import jakarta.persistence.*;
 import lombok.Getter;
@@ -14,7 +14,7 @@ import java.time.LocalDateTime;
 @NoArgsConstructor
 @Entity
 @Table(name = "beans")
-public class BeanEntity {
+public class Bean {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -23,7 +23,7 @@ public class BeanEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "roaster_id", nullable = false)
-    private RoasterEntity roaster;
+    private Roaster roaster;
 
     @Column(name = "name_ko", nullable = false, length = 150)
     private String nameKo;

--- a/src/main/java/dripnote/bean/domain/BeanBookmark.java
+++ b/src/main/java/dripnote/bean/domain/BeanBookmark.java
@@ -1,6 +1,6 @@
-package dripnote.bean.entity;
+package dripnote.bean.domain;
 
-import dripnote.user.entity.UserEntity;
+import dripnote.user.domain.User;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -14,7 +14,7 @@ import java.time.LocalDateTime;
 @NoArgsConstructor
 @Entity
 @Table(name = "bean_bookmarks")
-public class BeanBookmarkEntity {
+public class BeanBookmark {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -23,11 +23,11 @@ public class BeanBookmarkEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
-    private UserEntity user;
+    private User user;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "bean_id", nullable = false)
-    private BeanEntity bean;
+    private Bean bean;
 
     @CreationTimestamp
     @Column(name = "created_at", nullable = false, updatable = false)

--- a/src/main/java/dripnote/bean/domain/BeanImage.java
+++ b/src/main/java/dripnote/bean/domain/BeanImage.java
@@ -1,6 +1,5 @@
-package dripnote.bean.entity;
+package dripnote.bean.domain;
 
-import dripnote.bean.enums.NoteType;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -13,27 +12,23 @@ import java.time.LocalDateTime;
 @Setter
 @NoArgsConstructor
 @Entity
-@Table(name = "bean_tasting_notes")
-public class BeanTastingNoteEntity {
+@Table(name = "bean_images")
+public class BeanImage {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "bean_tasting_note_id")
-    private Long beanTastingNoteId;
+    @Column(name = "bean_image_id")
+    private Long beanImageId;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "bean_id", nullable = false)
-    private BeanEntity bean;
+    private Bean bean;
 
-    @Column(name = "note_name", nullable = false, length = 50)
-    private String noteName;
+    @Column(name = "image_url", nullable = false, length = 500)
+    private String imageUrl;
 
-    @Enumerated(EnumType.STRING)
-    @Column(name = "note_type", nullable = false, length = 10)
-    private NoteType noteType = NoteType.SUB;
-
-    @Column(name = "intensity")
-    private Integer intensity;
+    @Column(name = "image_type", length = 20)
+    private String imageType;
 
     @Column(name = "sort_order", nullable = false)
     private Integer sortOrder = 1;

--- a/src/main/java/dripnote/bean/domain/BeanReview.java
+++ b/src/main/java/dripnote/bean/domain/BeanReview.java
@@ -1,5 +1,6 @@
-package dripnote.lesson.entity;
+package dripnote.bean.domain;
 
+import dripnote.user.domain.User;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -13,17 +14,21 @@ import java.time.LocalDateTime;
 @Setter
 @NoArgsConstructor
 @Entity
-@Table(name = "class_reviews")
-public class ClassReviewEntity {
+@Table(name = "bean_reviews")
+public class BeanReview {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "class_review_id")
-    private Long classReviewId;
+    @Column(name = "bean_review_id")
+    private Long beanReviewId;
 
-    @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "booking_id", nullable = false)
-    private BookingEntity booking;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "bean_id", nullable = false)
+    private Bean bean;
 
     @Column(name = "rating", nullable = false)
     private Integer rating;

--- a/src/main/java/dripnote/bean/domain/BeanTastingNote.java
+++ b/src/main/java/dripnote/bean/domain/BeanTastingNote.java
@@ -1,5 +1,6 @@
-package dripnote.bean.entity;
+package dripnote.bean.domain;
 
+import dripnote.bean.enums.NoteType;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -12,23 +13,27 @@ import java.time.LocalDateTime;
 @Setter
 @NoArgsConstructor
 @Entity
-@Table(name = "bean_images")
-public class BeanImageEntity {
+@Table(name = "bean_tasting_notes")
+public class BeanTastingNote {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "bean_image_id")
-    private Long beanImageId;
+    @Column(name = "bean_tasting_note_id")
+    private Long beanTastingNoteId;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "bean_id", nullable = false)
-    private BeanEntity bean;
+    private Bean bean;
 
-    @Column(name = "image_url", nullable = false, length = 500)
-    private String imageUrl;
+    @Column(name = "note_name", nullable = false, length = 50)
+    private String noteName;
 
-    @Column(name = "image_type", length = 20)
-    private String imageType;
+    @Enumerated(EnumType.STRING)
+    @Column(name = "note_type", nullable = false, length = 10)
+    private NoteType noteType = NoteType.SUB;
+
+    @Column(name = "intensity")
+    private Integer intensity;
 
     @Column(name = "sort_order", nullable = false)
     private Integer sortOrder = 1;

--- a/src/main/java/dripnote/bean/domain/Roaster.java
+++ b/src/main/java/dripnote/bean/domain/Roaster.java
@@ -1,4 +1,4 @@
-package dripnote.bean.entity;
+package dripnote.bean.domain;
 
 import jakarta.persistence.*;
 import lombok.Getter;
@@ -14,7 +14,10 @@ import java.time.LocalDateTime;
 @NoArgsConstructor
 @Entity
 @Table(name = "roasters")
-public class RoasterEntity {
+public class Roaster {
+    /**
+     * city, country, updatedAt -> 해당 데이터는 현재 불필요할 것 같아서 삭제했습니다!
+     */
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -27,12 +30,6 @@ public class RoasterEntity {
     @Column(name = "name_en", length = 100)
     private String nameEn;
 
-    @Column(name = "city", length = 100)
-    private String city;
-
-    @Column(name = "country", length = 100)
-    private String country;
-
     @Column(name = "homepage_url", length = 500)
     private String homepageUrl;
 
@@ -42,8 +39,4 @@ public class RoasterEntity {
     @CreationTimestamp
     @Column(name = "created_at", nullable = false, updatable = false)
     private LocalDateTime createdAt;
-
-    @UpdateTimestamp
-    @Column(name = "updated_at", nullable = false)
-    private LocalDateTime updatedAt;
 }

--- a/src/main/java/dripnote/bean/repository/BeanBookmarksRepository.java
+++ b/src/main/java/dripnote/bean/repository/BeanBookmarksRepository.java
@@ -1,9 +1,9 @@
 package dripnote.bean.repository;
 
-import dripnote.bean.entity.BeanBookmarkEntity;
+import dripnote.bean.domain.BeanBookmark;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface BeanBookmarksRepository extends JpaRepository<BeanBookmarkEntity, Long> {
+public interface BeanBookmarksRepository extends JpaRepository<BeanBookmark, Long> {
 }

--- a/src/main/java/dripnote/bean/repository/BeanImagesRepository.java
+++ b/src/main/java/dripnote/bean/repository/BeanImagesRepository.java
@@ -1,7 +1,7 @@
 package dripnote.bean.repository;
 
-import dripnote.bean.entity.BeanImageEntity;
+import dripnote.bean.domain.BeanImage;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface BeanImagesRepository extends JpaRepository<BeanImageEntity, Long> {
+public interface BeanImagesRepository extends JpaRepository<BeanImage, Long> {
 }

--- a/src/main/java/dripnote/bean/repository/BeanReviewsRepository.java
+++ b/src/main/java/dripnote/bean/repository/BeanReviewsRepository.java
@@ -1,7 +1,7 @@
 package dripnote.bean.repository;
 
-import dripnote.bean.entity.BeanReviewEntity;
+import dripnote.bean.domain.BeanReview;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface BeanReviewsRepository extends JpaRepository<BeanReviewEntity, Long> {
+public interface BeanReviewsRepository extends JpaRepository<BeanReview, Long> {
 }

--- a/src/main/java/dripnote/bean/repository/BeanTastingNotesRepository.java
+++ b/src/main/java/dripnote/bean/repository/BeanTastingNotesRepository.java
@@ -1,7 +1,7 @@
 package dripnote.bean.repository;
 
-import dripnote.bean.entity.BeanTastingNoteEntity;
+import dripnote.bean.domain.BeanTastingNote;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface BeanTastingNotesRepository extends JpaRepository<BeanTastingNoteEntity, Long> {
+public interface BeanTastingNotesRepository extends JpaRepository<BeanTastingNote, Long> {
 }

--- a/src/main/java/dripnote/bean/repository/BeansRepository.java
+++ b/src/main/java/dripnote/bean/repository/BeansRepository.java
@@ -1,7 +1,7 @@
 package dripnote.bean.repository;
 
-import dripnote.bean.entity.BeanEntity;
+import dripnote.bean.domain.Bean;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface BeansRepository extends JpaRepository<BeanEntity, Long> {
+public interface BeansRepository extends JpaRepository<Bean, Long> {
 }

--- a/src/main/java/dripnote/bean/repository/RoastersRepository.java
+++ b/src/main/java/dripnote/bean/repository/RoastersRepository.java
@@ -1,7 +1,7 @@
 package dripnote.bean.repository;
 
-import dripnote.bean.entity.RoasterEntity;
+import dripnote.bean.domain.Roaster;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface RoastersRepository extends JpaRepository<RoasterEntity, Long> {
+public interface RoastersRepository extends JpaRepository<Roaster, Long> {
 }

--- a/src/main/java/dripnote/common/config/SecurityConfig.java
+++ b/src/main/java/dripnote/common/config/SecurityConfig.java
@@ -10,9 +10,14 @@ import org.springframework.security.web.SecurityFilterChain;
 public class SecurityConfig {
 
     /* [삭제된 부분]
-       - .formLogin(...): 이제 아이디/비밀번호 로그인을 쓰지 않으므로 삭제합니다.
-       - .rememberMe(...): 이 기능은 UserDetailsService가 필요하여 에러를 일으켰으므로 삭제합니다.
-       - /signup: OAuth2 전용이므로 별도의 회원가입 페이지는 필요 없어 제외했습니다.
+       - .invalidateHttpSession(true): 디폴트값이 true라 불필요할 것 같아서 삭제합니다.
+       - .logoutUrl("/logout"): 디폴트값이 "/logout"이라 불필요할 것 같아서 삭제합니다.
+       - requestMatchers 내부에 "/main" 삭제, 메인페이지는 "/"으로 사용
+       [추가된 부분]
+       - requestMatchers 내부에 "/oauth2/**" 추가, 추후에 oauth 요청 시 사용
+       [변경된 부분]
+       - .logoutSuccessUrl("/main") -> .logoutSuccessUrl("/")
+       - .defaultSuccessUrl("/main", true) -> .defaultSuccessUrl("/", true)
     */
 
     @Bean
@@ -26,14 +31,13 @@ public class SecurityConfig {
                         .requestMatchers(PathRequest.toStaticResources().atCommonLocations()).permitAll()
                         .requestMatchers(
                                 "/",
-                                "/main",
-                                "/signin",  // 로그인 페이지
+                                "/signin",
                                 "/beans/**",
-                                "/classes/**"
+                                "/classes/**",
+                                "/oauth2/**"
                         ).permitAll()
                         .requestMatchers(
-                                "/mypage/**",
-                                "/reservations/**"
+                                "/mypage/**"
                         ).authenticated()
                         .anyRequest().authenticated() // 나머지는 로그인한 유저만
                 )
@@ -41,14 +45,12 @@ public class SecurityConfig {
                 // OAuth2 로그인 설정
                 .oauth2Login(oauth -> oauth
                         .loginPage("/signin") // 커스텀 로그인 페이지 사용 시
-                        .defaultSuccessUrl("/main", true) // 로그인 성공 시 이동할 곳
+                        .defaultSuccessUrl("/", true) // 로그인 성공 시 이동할 곳
                 )
 
                 // 로그아웃 설정
                 .logout(logout -> logout
-                        .logoutUrl("/logout")
-                        .logoutSuccessUrl("/main")
-                        .invalidateHttpSession(true)
+                        .logoutSuccessUrl("/")
                         .deleteCookies("JSESSIONID")
                 );
         return http.build();

--- a/src/main/java/dripnote/lesson/domain/Booking.java
+++ b/src/main/java/dripnote/lesson/domain/Booking.java
@@ -1,7 +1,7 @@
-package dripnote.lesson.entity;
+package dripnote.lesson.domain;
 
 import dripnote.lesson.enums.BookingStatus;
-import dripnote.user.entity.UserEntity;
+import dripnote.user.domain.User;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -16,7 +16,7 @@ import java.time.LocalDateTime;
 @NoArgsConstructor
 @Entity
 @Table(name = "bookings")
-public class BookingEntity {
+public class Booking {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -25,11 +25,11 @@ public class BookingEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "class_schedule_id", nullable = false)
-    private ClassScheduleEntity classSchedule;
+    private ClassSchedule classSchedule;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
-    private UserEntity user;
+    private User user;
 
     @Enumerated(EnumType.STRING)
     @Column(name = "booking_status", nullable = false, length = 20)

--- a/src/main/java/dripnote/lesson/domain/Class.java
+++ b/src/main/java/dripnote/lesson/domain/Class.java
@@ -1,7 +1,7 @@
-package dripnote.lesson.entity;
+package dripnote.lesson.domain;
 
 import dripnote.lesson.enums.DifficultyLevel;
-import dripnote.user.entity.UserEntity;
+import dripnote.user.domain.User;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -17,7 +17,7 @@ import java.time.LocalDateTime;
 @NoArgsConstructor
 @Entity
 @Table(name = "classes")
-public class ClassEntity {
+public class Class {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -26,7 +26,7 @@ public class ClassEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "host_user_id", nullable = false)
-    private UserEntity hostUser;
+    private User hostUser;
 
     @Column(name = "title", nullable = false, length = 200)
     private String title;

--- a/src/main/java/dripnote/lesson/domain/ClassImage.java
+++ b/src/main/java/dripnote/lesson/domain/ClassImage.java
@@ -1,4 +1,4 @@
-package dripnote.lesson.entity;
+package dripnote.lesson.domain;
 
 import jakarta.persistence.*;
 import lombok.Getter;
@@ -13,7 +13,7 @@ import java.time.LocalDateTime;
 @NoArgsConstructor
 @Entity
 @Table(name = "class_images")
-public class ClassImageEntity {
+public class ClassImage {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -22,7 +22,7 @@ public class ClassImageEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "class_id", nullable = false)
-    private ClassEntity classEntity;
+    private Class aClass;
 
     @Column(name = "image_url", nullable = false, length = 500)
     private String imageUrl;

--- a/src/main/java/dripnote/lesson/domain/ClassReview.java
+++ b/src/main/java/dripnote/lesson/domain/ClassReview.java
@@ -1,6 +1,5 @@
-package dripnote.bean.entity;
+package dripnote.lesson.domain;
 
-import dripnote.user.entity.UserEntity;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -14,21 +13,17 @@ import java.time.LocalDateTime;
 @Setter
 @NoArgsConstructor
 @Entity
-@Table(name = "bean_reviews")
-public class BeanReviewEntity {
+@Table(name = "class_reviews")
+public class ClassReview {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "bean_review_id")
-    private Long beanReviewId;
+    @Column(name = "class_review_id")
+    private Long classReviewId;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id", nullable = false)
-    private UserEntity user;
-
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "bean_id", nullable = false)
-    private BeanEntity bean;
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "booking_id", nullable = false)
+    private Booking booking;
 
     @Column(name = "rating", nullable = false)
     private Integer rating;

--- a/src/main/java/dripnote/lesson/domain/ClassSchedule.java
+++ b/src/main/java/dripnote/lesson/domain/ClassSchedule.java
@@ -1,4 +1,4 @@
-package dripnote.lesson.entity;
+package dripnote.lesson.domain;
 
 import dripnote.lesson.enums.ScheduleStatus;
 import jakarta.persistence.*;
@@ -17,7 +17,7 @@ import java.time.LocalTime;
 @NoArgsConstructor
 @Entity
 @Table(name = "class_schedules")
-public class ClassScheduleEntity {
+public class ClassSchedule {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -26,7 +26,7 @@ public class ClassScheduleEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "class_id", nullable = false)
-    private ClassEntity classEntity;
+    private Class aClass;
 
     @Column(name = "class_date", nullable = false)
     private LocalDate classDate;

--- a/src/main/java/dripnote/lesson/domain/Payment.java
+++ b/src/main/java/dripnote/lesson/domain/Payment.java
@@ -1,4 +1,4 @@
-package dripnote.lesson.entity;
+package dripnote.lesson.domain;
 
 import dripnote.lesson.enums.PaymentProvider;
 import dripnote.lesson.enums.PaymentStatus;
@@ -16,7 +16,7 @@ import java.time.LocalDateTime;
 @NoArgsConstructor
 @Entity
 @Table(name = "payments")
-public class PaymentEntity {
+public class Payment {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -25,7 +25,7 @@ public class PaymentEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "booking_id", nullable = false)
-    private BookingEntity booking;
+    private Booking booking;
 
     @Enumerated(EnumType.STRING)
     @Column(name = "provider", nullable = false, length = 20)

--- a/src/main/java/dripnote/lesson/repository/BookingRepository.java
+++ b/src/main/java/dripnote/lesson/repository/BookingRepository.java
@@ -1,7 +1,7 @@
 package dripnote.lesson.repository;
 
-import dripnote.lesson.entity.BookingEntity;
+import dripnote.lesson.domain.Booking;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface BookingRepository extends JpaRepository<BookingEntity, Long> {
+public interface BookingRepository extends JpaRepository<Booking, Long> {
 }

--- a/src/main/java/dripnote/lesson/repository/ClassImageRepository.java
+++ b/src/main/java/dripnote/lesson/repository/ClassImageRepository.java
@@ -1,7 +1,7 @@
 package dripnote.lesson.repository;
 
-import dripnote.lesson.entity.ClassImageEntity;
+import dripnote.lesson.domain.ClassImage;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface ClassImageRepository extends JpaRepository<ClassImageEntity, Long> {
+public interface ClassImageRepository extends JpaRepository<ClassImage, Long> {
 }

--- a/src/main/java/dripnote/lesson/repository/ClassRepository.java
+++ b/src/main/java/dripnote/lesson/repository/ClassRepository.java
@@ -1,7 +1,7 @@
 package dripnote.lesson.repository;
 
-import dripnote.lesson.entity.ClassEntity;
+import dripnote.lesson.domain.Class;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface ClassRepository extends JpaRepository<ClassEntity, Long> {
+public interface ClassRepository extends JpaRepository<Class, Long> {
 }

--- a/src/main/java/dripnote/lesson/repository/ClassReviewRepository.java
+++ b/src/main/java/dripnote/lesson/repository/ClassReviewRepository.java
@@ -1,7 +1,7 @@
 package dripnote.lesson.repository;
 
-import dripnote.lesson.entity.ClassReviewEntity;
+import dripnote.lesson.domain.ClassReview;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface ClassReviewRepository extends JpaRepository<ClassReviewEntity, Long> {
+public interface ClassReviewRepository extends JpaRepository<ClassReview, Long> {
 }

--- a/src/main/java/dripnote/lesson/repository/ClassScheduleRepository.java
+++ b/src/main/java/dripnote/lesson/repository/ClassScheduleRepository.java
@@ -1,7 +1,7 @@
 package dripnote.lesson.repository;
 
-import dripnote.lesson.entity.ClassScheduleEntity;
+import dripnote.lesson.domain.ClassSchedule;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface ClassScheduleRepository extends JpaRepository<ClassScheduleEntity, Long> {
+public interface ClassScheduleRepository extends JpaRepository<ClassSchedule, Long> {
 }

--- a/src/main/java/dripnote/lesson/repository/PaymentRepository.java
+++ b/src/main/java/dripnote/lesson/repository/PaymentRepository.java
@@ -1,7 +1,7 @@
 package dripnote.lesson.repository;
 
-import dripnote.lesson.entity.PaymentEntity;
+import dripnote.lesson.domain.Payment;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface PaymentRepository extends JpaRepository<PaymentEntity, Long> {
+public interface PaymentRepository extends JpaRepository<Payment, Long> {
 }

--- a/src/main/java/dripnote/user/domain/User.java
+++ b/src/main/java/dripnote/user/domain/User.java
@@ -1,14 +1,12 @@
-package dripnote.user.entity;
+package dripnote.user.domain;
 
 import dripnote.user.enums.UserProvider;
 import dripnote.user.enums.UserRole;
-import dripnote.user.enums.UserStatus;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.hibernate.annotations.CreationTimestamp;
-import org.hibernate.annotations.UpdateTimestamp;
 
 import java.time.LocalDateTime;
 
@@ -16,16 +14,13 @@ import java.time.LocalDateTime;
 @Setter
 @NoArgsConstructor
 @Entity
-/**
- * 플랫폼마다 provider_id가 겹칠 수 있어서
- * 복합 유니크 제약조건 {provider, provider_id}를 추가
- * -> 플랫폼은 달라도 provider_id가 같을 수 있음
- */
 @Table(name = "users", uniqueConstraints = {
         @UniqueConstraint(name = "unique_provider_id", columnNames = {"provider", "provider_id"})
 })
-public class UserEntity {
-
+public class User {
+    /**
+     * updatedAt, profileImageUrl, status -> 해당 데이터는 현재 불필요할 것 같아서 삭제했습니다!
+     */
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "user_id")
@@ -37,17 +32,14 @@ public class UserEntity {
 
     // OAuth: google, kakao, naver 등
     @Column(name = "provider", nullable = false, length = 20)
-    private String provider;
+    private UserProvider provider;
 
     // 해당 플랫폼에서 제공하는 고유 식별 번호 (sub, id 등)
     @Column(name = "provider_id", nullable = false, length = 255)
-    private UserProvider providerId;
+    private String providerId;
 
     @Column(name = "nickname", nullable = false, length = 50)
     private String nickname;
-
-    @Column(name = "profile_image_url", length = 500)
-    private String profileImageUrl;
 
     /* 네이버/카카오에서 제공하는 성별, 연령대 등 추가 정보를 저장하고 싶을 때 사용 */
     // @Column(name = "gender", length = 10)
@@ -60,15 +52,7 @@ public class UserEntity {
     @Column(name = "role", nullable = false, length = 20)
     private UserRole role = UserRole.USER;
 
-    @Enumerated(EnumType.STRING)
-    @Column(name = "status", nullable = false, length = 20)
-    private UserStatus status = UserStatus.ACTIVE;
-
     @CreationTimestamp
     @Column(name = "created_at", nullable = false, updatable = false)
     private LocalDateTime createdAt;
-
-    @UpdateTimestamp
-    @Column(name = "updated_at", nullable = false)
-    private LocalDateTime updatedAt;
 }

--- a/src/main/java/dripnote/user/repository/UserRepository.java
+++ b/src/main/java/dripnote/user/repository/UserRepository.java
@@ -1,7 +1,7 @@
 package dripnote.user.repository;
 
-import dripnote.user.entity.UserEntity;
+import dripnote.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface UserRepository extends JpaRepository<UserEntity, Long> {
+public interface UserRepository extends JpaRepository<User, Long> {
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #6 

## 📝작업 내용

> SecurityConfig 내용 수정하고 entity를 domain으로 전부 변경하였습니다. 또한 기존 entity 명칭을 수정하였습니다,
> 예) UserEntity -> User
> 추가적으로 사용자, 원두 기능 내에 필요없다고 생각되는 entity 속성을 삭제하였습니다.

## 중점적으로 리뷰받고 싶은 부분

> 삭제된 entity 속성 중 필요하다고 생각되는 부분이 있다면 말씀해주시면 좋을 것 같아요.

## 논의하고 싶은 부분

> 현재 로그인 시 무조건 메인페이지로 리디렉션 되도록 되어있는데 이 상태를 유지할지 아니면 사용자가 본래 보던 페이지로 돌아가도록 할지 논의 해보면 좋을 것 같습니다.

## 🫡 참고사항

> SecurityConfig 내부에 별도의 인증 없이 허용되는 페이지는 api 명세가 나오지않아서 제대로 작성하지 못했습니다. 그 부분은 감안하고 봐주시면 감사하겠습니다.