### PR TITLE
[feature] Main, Develop CI/CD 파이프라인 구축

### DIFF
--- a/.github/workflows/server_cd.yml
+++ b/.github/workflows/server_cd.yml
@@ -1,26 +1,30 @@
-name: Server CD
+﻿name: Server CD
 
 on:
   push:
     branches:
       - main
       - develop
-      - feature/#15-CI-CD
+      - test-CI/CD
 
 concurrency:
   group: server-cd-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
-  build-and-push:
+  # develop, test-CI/CD 브랜치는 라즈베리파이용 ARM64 이미지를 빌드합니다.
+  build-and-push-pi:
+    if: github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/test-CI/CD'
     runs-on: ubuntu-latest
     permissions:
       contents: read
 
     steps:
+      # 저장소 코드를 가져옵니다.
       - name: Checkout
         uses: actions/checkout@v4
 
+      # Java 21과 Gradle 캐시를 설정합니다.
       - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
@@ -28,46 +32,57 @@ jobs:
           distribution: temurin
           cache: gradle
 
+      # Gradle 환경을 초기화합니다.
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
 
+      # gradlew 실행 권한을 부여합니다.
       - name: Grant execute permission
         run: chmod +x ./gradlew
 
+      # Spring Boot jar를 빌드합니다.
       - name: Build jar
         run: ./gradlew clean bootJar --no-daemon
 
+      # ARM64 빌드를 위해 QEMU를 설정합니다.
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
 
+      # Docker Buildx를 활성화합니다.
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Login to registry
+      # Docker Registry에 로그인합니다.
+      - name: Login to registry for Raspberry Pi
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
-      - name: Build and push ARM64 image
+      # 라즈베리파이용 ARM64 이미지를 빌드하고 push합니다.
+      - name: Build and push ARM64 image for Raspberry Pi
         uses: docker/build-push-action@v6
         with:
           context: .
           push: true
           platforms: linux/arm64
-          tags: ${{ secrets.DOCKER_IMAGE }}
+          tags: ${{ secrets.PI_DOCKER_IMAGE }}
 
-  deploy:
+  # develop, test-CI/CD 브랜치는 라즈베리파이 서버로 배포합니다.
+  deploy-pi:
+    if: github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/test-CI/CD'
     runs-on: ubuntu-latest
-    needs: build-and-push
+    needs: build-and-push-pi
     permissions:
       contents: read
 
     steps:
+      # 저장소 코드를 가져옵니다.
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Prepare deploy directory
+      # 서버에 deploy 폴더를 준비합니다.
+      - name: Prepare Raspberry Pi deploy directory
         uses: appleboy/ssh-action@v1.2.0
         with:
           host: ${{ secrets.PI_HOST }}
@@ -77,7 +92,8 @@ jobs:
           script: |
             mkdir -p /home/${{ secrets.PI_USERNAME }}/deploy
 
-      - name: Upload deploy files
+      # deploy 폴더의 파일들을 서버로 업로드합니다.
+      - name: Upload deploy files to Raspberry Pi
         uses: appleboy/scp-action@v0.1.7
         with:
           host: ${{ secrets.PI_HOST }}
@@ -88,6 +104,7 @@ jobs:
           target: "/home/${{ secrets.PI_USERNAME }}"
           strip_components: 1
 
+      # 서버에서 최신 이미지를 pull하고 배포 스크립트를 실행합니다.
       - name: Deploy on Raspberry Pi
         uses: appleboy/ssh-action@v1.2.0
         with:
@@ -97,10 +114,121 @@ jobs:
           port: ${{ secrets.PI_PORT }}
           script: |
             export USERNAME='${{ secrets.PI_USERNAME }}'
-            export DOCKER_APP_IMAGE='${{ secrets.DOCKER_IMAGE }}'
+            export DOCKER_APP_IMAGE='${{ secrets.PI_DOCKER_IMAGE }}'
             export COMPOSE_FILE='/home/${{ secrets.PI_USERNAME }}/deploy/compose.blue-green.yml'
             export NGINX_CONFIG_PATH='/etc/nginx/sites-available/ssl.conf'
             chmod +x /home/${{ secrets.PI_USERNAME }}/deploy/deploy.sh
-            docker pull '${{ secrets.DOCKER_IMAGE }}'
+            docker pull '${{ secrets.PI_DOCKER_IMAGE }}'
             sudo -E /home/${{ secrets.PI_USERNAME }}/deploy/deploy.sh
             docker image prune -af
+
+  # main 브랜치는 GCP 운영 서버용 이미지를 빌드합니다.
+  build-and-push-gcp:
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      # 저장소 코드를 가져옵니다.
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # Java 21과 Gradle 캐시를 설정합니다.
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: "21"
+          distribution: temurin
+          cache: gradle
+
+      # Gradle 환경을 초기화합니다.
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      # gradlew 실행 권한을 부여합니다.
+      - name: Grant execute permission
+        run: chmod +x ./gradlew
+
+      # Spring Boot jar를 빌드합니다.
+      - name: Build jar
+        run: ./gradlew clean bootJar --no-daemon
+
+      # GCP 인증을 수행합니다.
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.GCP_GCE_SA_KEY }}
+
+      # gcloud CLI를 설치합니다.
+      - name: Set up Google Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          project_id: ${{ secrets.GCP_PROJECT_ID }}
+
+      # GCP Container Registry 인증을 설정합니다.
+      - name: Configure Docker auth for GCP registry
+        run: gcloud auth configure-docker --quiet
+
+      # GCP에 올릴 이미지를 빌드합니다.
+      - name: Build Docker image for GCP
+        run: docker build -t "${{ secrets.GCP_DOCKER_IMAGE }}" .
+
+      # GCP Registry로 이미지를 push합니다.
+      - name: Push Docker image for GCP
+        run: docker push "${{ secrets.GCP_DOCKER_IMAGE }}"
+
+  # main 브랜치는 GCP 운영 서버로 배포합니다.
+  deploy-gcp:
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    needs: build-and-push-gcp
+    permissions:
+      contents: read
+
+    steps:
+      # 저장소 코드를 가져옵니다.
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # GCP 인증을 수행합니다.
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.GCP_GCE_SA_KEY }}
+
+      # gcloud CLI를 설치합니다.
+      - name: Set up Google Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          project_id: ${{ secrets.GCP_PROJECT_ID }}
+
+      # GCP 서버에 deploy 폴더를 준비합니다.
+      - name: Prepare GCP deploy directory
+        run: |
+          gcloud compute ssh "${{ secrets.GCP_INSTANCE_USER }}@${{ secrets.GCP_INSTANCE_NAME }}" \
+            --zone "${{ secrets.GCP_ZONE }}" \
+            --command "mkdir -p /home/${{ secrets.GCP_INSTANCE_USER }}/deploy"
+
+      # deploy 폴더의 파일들을 GCP 서버로 업로드합니다.
+      - name: Upload deploy files to GCP
+        run: |
+          gcloud compute scp --recurse ./deploy \
+            "${{ secrets.GCP_INSTANCE_USER }}@${{ secrets.GCP_INSTANCE_NAME }}:/home/${{ secrets.GCP_INSTANCE_USER }}" \
+            --zone "${{ secrets.GCP_ZONE }}"
+
+      # GCP 서버에서 최신 이미지를 pull하고 배포 스크립트를 실행합니다.
+      - name: Deploy on GCP
+        run: |
+          gcloud compute ssh "${{ secrets.GCP_INSTANCE_USER }}@${{ secrets.GCP_INSTANCE_NAME }}" \
+            --zone "${{ secrets.GCP_ZONE }}" \
+            --command "
+              export USERNAME='${{ secrets.GCP_INSTANCE_USER }}' &&
+              export DOCKER_APP_IMAGE='${{ secrets.GCP_DOCKER_IMAGE }}' &&
+              export COMPOSE_FILE='/home/${{ secrets.GCP_INSTANCE_USER }}/deploy/compose.blue-green.yml' &&
+              export NGINX_CONFIG_PATH='/etc/nginx/sites-available/ssl.conf' &&
+              chmod +x /home/${{ secrets.GCP_INSTANCE_USER }}/deploy/deploy.sh &&
+              docker pull '${{ secrets.GCP_DOCKER_IMAGE }}' &&
+              sudo -E /home/${{ secrets.GCP_INSTANCE_USER }}/deploy/deploy.sh &&
+              docker image prune -af
+            "

--- a/.github/workflows/server_cd.yml
+++ b/.github/workflows/server_cd.yml
@@ -5,16 +5,17 @@ on:
     branches:
       - main
       - develop
-      - test-CI/CD
+      - test/#17-CI-CD-test
+      - feature/#15-CI-CD
 
 concurrency:
   group: server-cd-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
-  # develop, test-CI/CD 브랜치는 라즈베리파이용 ARM64 이미지를 빌드합니다.
+  # develop, test-CI/CD 브랜치는 라즈베리파이용 ARM64 이미지를 빌드합니다
   build-and-push-pi:
-    if: github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/test-CI/CD'
+    if: github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/test/#17-CI-CD-test'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -66,11 +67,11 @@ jobs:
           context: .
           push: true
           platforms: linux/arm64
-          tags: ${{ secrets.PI_DOCKER_IMAGE }}
+          tags: ${{ secrets.PI_DOCKER_IMAGE }} # 예: username/repository:tag
 
   # develop, test-CI/CD 브랜치는 라즈베리파이 서버로 배포합니다.
   deploy-pi:
-    if: github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/test-CI/CD'
+    if: github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/test/#17-CI-CD-test'
     runs-on: ubuntu-latest
     needs: build-and-push-pi
     permissions:
@@ -89,6 +90,7 @@ jobs:
           username: ${{ secrets.PI_USERNAME }}
           key: ${{ secrets.PI_SSH_KEY }}
           port: ${{ secrets.PI_PORT }}
+          script_stop: true
           script: |
             mkdir -p /home/${{ secrets.PI_USERNAME }}/deploy
 
@@ -101,7 +103,7 @@ jobs:
           key: ${{ secrets.PI_SSH_KEY }}
           port: ${{ secrets.PI_PORT }}
           source: "deploy/*"
-          target: "/home/${{ secrets.PI_USERNAME }}"
+          target: "/home/${{ secrets.PI_USERNAME }}/deploy"
           strip_components: 1
 
       # 서버에서 최신 이미지를 pull하고 배포 스크립트를 실행합니다.
@@ -112,6 +114,7 @@ jobs:
           username: ${{ secrets.PI_USERNAME }}
           key: ${{ secrets.PI_SSH_KEY }}
           port: ${{ secrets.PI_PORT }}
+          script_stop: true
           script: |
             export USERNAME='${{ secrets.PI_USERNAME }}'
             export DOCKER_APP_IMAGE='${{ secrets.PI_DOCKER_IMAGE }}'
@@ -119,15 +122,16 @@ jobs:
             export NGINX_CONFIG_PATH='/etc/nginx/sites-available/ssl.conf'
             chmod +x /home/${{ secrets.PI_USERNAME }}/deploy/deploy.sh
             docker pull '${{ secrets.PI_DOCKER_IMAGE }}'
-            sudo -E /home/${{ secrets.PI_USERNAME }}/deploy/deploy.sh
+            /home/${{ secrets.PI_USERNAME }}/deploy/deploy.sh
             docker image prune -af
 
   # main 브랜치는 GCP 운영 서버용 이미지를 빌드합니다.
   build-and-push-gcp:
-    if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/feature/#15-CI-CD'
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      id-token: write
 
     steps:
       # 저장소 코드를 가져옵니다.
@@ -156,9 +160,10 @@ jobs:
 
       # GCP 인증을 수행합니다.
       - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
-          credentials_json: ${{ secrets.GCP_GCE_SA_KEY }}
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
 
       # gcloud CLI를 설치합니다.
       - name: Set up Google Cloud SDK
@@ -180,11 +185,12 @@ jobs:
 
   # main 브랜치는 GCP 운영 서버로 배포합니다.
   deploy-gcp:
-    if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/feature/#15-CI-CD'
     runs-on: ubuntu-latest
     needs: build-and-push-gcp
     permissions:
       contents: read
+      id-token: write
 
     steps:
       # 저장소 코드를 가져옵니다.
@@ -193,9 +199,10 @@ jobs:
 
       # GCP 인증을 수행합니다.
       - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
-          credentials_json: ${{ secrets.GCP_GCE_SA_KEY }}
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
 
       # gcloud CLI를 설치합니다.
       - name: Set up Google Cloud SDK
@@ -229,6 +236,6 @@ jobs:
               export NGINX_CONFIG_PATH='/etc/nginx/sites-available/ssl.conf' &&
               chmod +x /home/${{ secrets.GCP_INSTANCE_USER }}/deploy/deploy.sh &&
               docker pull '${{ secrets.GCP_DOCKER_IMAGE }}' &&
-              sudo -E /home/${{ secrets.GCP_INSTANCE_USER }}/deploy/deploy.sh &&
+              /home/${{ secrets.GCP_INSTANCE_USER }}/deploy/deploy.sh &&
               docker image prune -af
             "

--- a/.github/workflows/server_cd.yml
+++ b/.github/workflows/server_cd.yml
@@ -3,18 +3,16 @@ name: Server CD
 on:
   push:
     branches:
-      - develop
-      - develop/be
       - main
+      - develop
+      - feature/#15-CI-CD
 
 concurrency:
   group: server-cd-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
-  test-build-and-push:
-    name: Test Build And Push
-    if: github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/develop/be'
+  build-and-push:
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -45,25 +43,23 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Login to test registry
+      - name: Login to registry
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.TEST_DOCKER_USERNAME }}
-          password: ${{ secrets.TEST_DOCKER_PASSWORD }}
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
 
-      - name: Build and push ARM64 test image
+      - name: Build and push ARM64 image
         uses: docker/build-push-action@v6
         with:
           context: .
           push: true
           platforms: linux/arm64
-          tags: ${{ secrets.TEST_DOCKER_IMAGE }}
+          tags: ${{ secrets.DOCKER_IMAGE }}
 
-  test-deploy:
-    name: Test Deploy To Raspberry Pi
-    if: github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/develop/be'
-    needs: test-build-and-push
+  deploy:
     runs-on: ubuntu-latest
+    needs: build-and-push
     permissions:
       contents: read
 
@@ -71,135 +67,40 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Prepare test deploy directory
+      - name: Prepare deploy directory
         uses: appleboy/ssh-action@v1.2.0
         with:
-          host: ${{ secrets.TEST_PI_HOST }}
-          username: ${{ secrets.TEST_PI_USERNAME }}
-          key: ${{ secrets.TEST_PI_SSH_KEY }}
-          port: ${{ secrets.TEST_PI_PORT }}
+          host: ${{ secrets.PI_HOST }}
+          username: ${{ secrets.PI_USERNAME }}
+          key: ${{ secrets.PI_SSH_KEY }}
+          port: ${{ secrets.PI_PORT }}
           script: |
-            mkdir -p /home/${{ secrets.TEST_PI_USERNAME }}/deploy
+            mkdir -p /home/${{ secrets.PI_USERNAME }}/deploy
 
-      - name: Upload deploy files to test server
+      - name: Upload deploy files
         uses: appleboy/scp-action@v0.1.7
         with:
-          host: ${{ secrets.TEST_PI_HOST }}
-          username: ${{ secrets.TEST_PI_USERNAME }}
-          key: ${{ secrets.TEST_PI_SSH_KEY }}
-          port: ${{ secrets.TEST_PI_PORT }}
+          host: ${{ secrets.PI_HOST }}
+          username: ${{ secrets.PI_USERNAME }}
+          key: ${{ secrets.PI_SSH_KEY }}
+          port: ${{ secrets.PI_PORT }}
           source: "deploy/*"
-          target: "/home/${{ secrets.TEST_PI_USERNAME }}"
+          target: "/home/${{ secrets.PI_USERNAME }}"
           strip_components: 1
 
-      - name: Run test deployment
+      - name: Deploy on Raspberry Pi
         uses: appleboy/ssh-action@v1.2.0
         with:
-          host: ${{ secrets.TEST_PI_HOST }}
-          username: ${{ secrets.TEST_PI_USERNAME }}
-          key: ${{ secrets.TEST_PI_SSH_KEY }}
-          port: ${{ secrets.TEST_PI_PORT }}
+          host: ${{ secrets.PI_HOST }}
+          username: ${{ secrets.PI_USERNAME }}
+          key: ${{ secrets.PI_SSH_KEY }}
+          port: ${{ secrets.PI_PORT }}
           script: |
-            export USERNAME='${{ secrets.TEST_PI_USERNAME }}'
-            export DOCKER_APP_IMAGE='${{ secrets.TEST_DOCKER_IMAGE }}'
-            export COMPOSE_FILE='/home/${{ secrets.TEST_PI_USERNAME }}/deploy/compose.blue-green.yml'
+            export USERNAME='${{ secrets.PI_USERNAME }}'
+            export DOCKER_APP_IMAGE='${{ secrets.DOCKER_IMAGE }}'
+            export COMPOSE_FILE='/home/${{ secrets.PI_USERNAME }}/deploy/compose.blue-green.yml'
             export NGINX_CONFIG_PATH='/etc/nginx/sites-available/ssl.conf'
-            chmod +x /home/${{ secrets.TEST_PI_USERNAME }}/deploy/deploy.sh
-            docker pull '${{ secrets.TEST_DOCKER_IMAGE }}'
-            sudo -E /home/${{ secrets.TEST_PI_USERNAME }}/deploy/deploy.sh
+            chmod +x /home/${{ secrets.PI_USERNAME }}/deploy/deploy.sh
+            docker pull '${{ secrets.DOCKER_IMAGE }}'
+            sudo -E /home/${{ secrets.PI_USERNAME }}/deploy/deploy.sh
             docker image prune -af
-
-  prod-build-and-push:
-    name: Prod Build And Push
-    if: github.ref == 'refs/heads/main'
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Set up JDK 21
-        uses: actions/setup-java@v4
-        with:
-          java-version: "21"
-          distribution: temurin
-          cache: gradle
-
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
-
-      - name: Grant execute permission
-        run: chmod +x ./gradlew
-
-      - name: Build jar
-        run: ./gradlew clean bootJar --no-daemon
-
-      - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v2
-        with:
-          credentials_json: ${{ secrets.GCP_GCE_SA_KEY }}
-
-      - name: Set up Google Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-        with:
-          project_id: ${{ secrets.GCP_PROJECT_ID }}
-
-      - name: Configure Docker auth
-        run: gcloud auth configure-docker --quiet
-
-      - name: Build Docker image
-        run: docker build -t "${{ secrets.GCP_DOCKER_IMAGE }}" .
-
-      - name: Push Docker image
-        run: docker push "${{ secrets.GCP_DOCKER_IMAGE }}"
-
-  prod-deploy:
-    name: Prod Deploy To GCP
-    if: github.ref == 'refs/heads/main'
-    needs: prod-build-and-push
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v2
-        with:
-          credentials_json: ${{ secrets.GCP_GCE_SA_KEY }}
-
-      - name: Set up Google Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-        with:
-          project_id: ${{ secrets.GCP_PROJECT_ID }}
-
-      - name: Prepare production deploy directory
-        run: |
-          gcloud compute ssh "${{ secrets.GCP_INSTANCE_USER }}@${{ secrets.GCP_INSTANCE_NAME }}" \
-            --zone "${{ secrets.GCP_ZONE }}" \
-            --command "mkdir -p /home/${{ secrets.GCP_INSTANCE_USER }}/deploy"
-
-      - name: Upload deploy files to production server
-        run: |
-          gcloud compute scp --recurse ./deploy \
-            "${{ secrets.GCP_INSTANCE_USER }}@${{ secrets.GCP_INSTANCE_NAME }}:/home/${{ secrets.GCP_INSTANCE_USER }}" \
-            --zone "${{ secrets.GCP_ZONE }}"
-
-      - name: Run production deployment
-        run: |
-          gcloud compute ssh "${{ secrets.GCP_INSTANCE_USER }}@${{ secrets.GCP_INSTANCE_NAME }}" \
-            --zone "${{ secrets.GCP_ZONE }}" \
-            --command "
-              export USERNAME='${{ secrets.GCP_INSTANCE_USER }}' &&
-              export DOCKER_APP_IMAGE='${{ secrets.GCP_DOCKER_IMAGE }}' &&
-              export COMPOSE_FILE='/home/${{ secrets.GCP_INSTANCE_USER }}/deploy/compose.blue-green.yml' &&
-              export NGINX_CONFIG_PATH='/etc/nginx/sites-available/ssl.conf' &&
-              chmod +x /home/${{ secrets.GCP_INSTANCE_USER }}/deploy/deploy.sh &&
-              docker pull '${{ secrets.GCP_DOCKER_IMAGE }}' &&
-              sudo -E /home/${{ secrets.GCP_INSTANCE_USER }}/deploy/deploy.sh &&
-              docker image prune -af
-            "

--- a/.github/workflows/server_cd.yml
+++ b/.github/workflows/server_cd.yml
@@ -1,0 +1,205 @@
+name: Server CD
+
+on:
+  push:
+    branches:
+      - develop
+      - develop/be
+      - main
+
+concurrency:
+  group: server-cd-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test-build-and-push:
+    name: Test Build And Push
+    if: github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/develop/be'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: "21"
+          distribution: temurin
+          cache: gradle
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Grant execute permission
+        run: chmod +x ./gradlew
+
+      - name: Build jar
+        run: ./gradlew clean bootJar --no-daemon
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to test registry
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.TEST_DOCKER_USERNAME }}
+          password: ${{ secrets.TEST_DOCKER_PASSWORD }}
+
+      - name: Build and push ARM64 test image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          platforms: linux/arm64
+          tags: ${{ secrets.TEST_DOCKER_IMAGE }}
+
+  test-deploy:
+    name: Test Deploy To Raspberry Pi
+    if: github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/develop/be'
+    needs: test-build-and-push
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Prepare test deploy directory
+        uses: appleboy/ssh-action@v1.2.0
+        with:
+          host: ${{ secrets.TEST_PI_HOST }}
+          username: ${{ secrets.TEST_PI_USERNAME }}
+          key: ${{ secrets.TEST_PI_SSH_KEY }}
+          port: ${{ secrets.TEST_PI_PORT }}
+          script: |
+            mkdir -p /home/${{ secrets.TEST_PI_USERNAME }}/deploy
+
+      - name: Upload deploy files to test server
+        uses: appleboy/scp-action@v0.1.7
+        with:
+          host: ${{ secrets.TEST_PI_HOST }}
+          username: ${{ secrets.TEST_PI_USERNAME }}
+          key: ${{ secrets.TEST_PI_SSH_KEY }}
+          port: ${{ secrets.TEST_PI_PORT }}
+          source: "deploy/*"
+          target: "/home/${{ secrets.TEST_PI_USERNAME }}"
+          strip_components: 1
+
+      - name: Run test deployment
+        uses: appleboy/ssh-action@v1.2.0
+        with:
+          host: ${{ secrets.TEST_PI_HOST }}
+          username: ${{ secrets.TEST_PI_USERNAME }}
+          key: ${{ secrets.TEST_PI_SSH_KEY }}
+          port: ${{ secrets.TEST_PI_PORT }}
+          script: |
+            export USERNAME='${{ secrets.TEST_PI_USERNAME }}'
+            export DOCKER_APP_IMAGE='${{ secrets.TEST_DOCKER_IMAGE }}'
+            export COMPOSE_FILE='/home/${{ secrets.TEST_PI_USERNAME }}/deploy/compose.blue-green.yml'
+            export NGINX_CONFIG_PATH='/etc/nginx/sites-available/ssl.conf'
+            chmod +x /home/${{ secrets.TEST_PI_USERNAME }}/deploy/deploy.sh
+            docker pull '${{ secrets.TEST_DOCKER_IMAGE }}'
+            sudo -E /home/${{ secrets.TEST_PI_USERNAME }}/deploy/deploy.sh
+            docker image prune -af
+
+  prod-build-and-push:
+    name: Prod Build And Push
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: "21"
+          distribution: temurin
+          cache: gradle
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Grant execute permission
+        run: chmod +x ./gradlew
+
+      - name: Build jar
+        run: ./gradlew clean bootJar --no-daemon
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.GCP_GCE_SA_KEY }}
+
+      - name: Set up Google Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          project_id: ${{ secrets.GCP_PROJECT_ID }}
+
+      - name: Configure Docker auth
+        run: gcloud auth configure-docker --quiet
+
+      - name: Build Docker image
+        run: docker build -t "${{ secrets.GCP_DOCKER_IMAGE }}" .
+
+      - name: Push Docker image
+        run: docker push "${{ secrets.GCP_DOCKER_IMAGE }}"
+
+  prod-deploy:
+    name: Prod Deploy To GCP
+    if: github.ref == 'refs/heads/main'
+    needs: prod-build-and-push
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.GCP_GCE_SA_KEY }}
+
+      - name: Set up Google Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          project_id: ${{ secrets.GCP_PROJECT_ID }}
+
+      - name: Prepare production deploy directory
+        run: |
+          gcloud compute ssh "${{ secrets.GCP_INSTANCE_USER }}@${{ secrets.GCP_INSTANCE_NAME }}" \
+            --zone "${{ secrets.GCP_ZONE }}" \
+            --command "mkdir -p /home/${{ secrets.GCP_INSTANCE_USER }}/deploy"
+
+      - name: Upload deploy files to production server
+        run: |
+          gcloud compute scp --recurse ./deploy \
+            "${{ secrets.GCP_INSTANCE_USER }}@${{ secrets.GCP_INSTANCE_NAME }}:/home/${{ secrets.GCP_INSTANCE_USER }}" \
+            --zone "${{ secrets.GCP_ZONE }}"
+
+      - name: Run production deployment
+        run: |
+          gcloud compute ssh "${{ secrets.GCP_INSTANCE_USER }}@${{ secrets.GCP_INSTANCE_NAME }}" \
+            --zone "${{ secrets.GCP_ZONE }}" \
+            --command "
+              export USERNAME='${{ secrets.GCP_INSTANCE_USER }}' &&
+              export DOCKER_APP_IMAGE='${{ secrets.GCP_DOCKER_IMAGE }}' &&
+              export COMPOSE_FILE='/home/${{ secrets.GCP_INSTANCE_USER }}/deploy/compose.blue-green.yml' &&
+              export NGINX_CONFIG_PATH='/etc/nginx/sites-available/ssl.conf' &&
+              chmod +x /home/${{ secrets.GCP_INSTANCE_USER }}/deploy/deploy.sh &&
+              docker pull '${{ secrets.GCP_DOCKER_IMAGE }}' &&
+              sudo -E /home/${{ secrets.GCP_INSTANCE_USER }}/deploy/deploy.sh &&
+              docker image prune -af
+            "

--- a/.github/workflows/server_cd.yml
+++ b/.github/workflows/server_cd.yml
@@ -5,8 +5,6 @@ on:
     branches:
       - main
       - develop
-      - test/#17-CI-CD-test
-      - feature/#15-CI-CD
 
 concurrency:
   group: server-cd-${{ github.ref }}
@@ -15,7 +13,7 @@ concurrency:
 jobs:
   # develop, test-CI/CD 브랜치는 라즈베리파이용 ARM64 이미지를 빌드합니다
   build-and-push-pi:
-    if: github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/test/#17-CI-CD-test'
+    if: github.ref == 'refs/heads/develop'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -71,7 +69,7 @@ jobs:
 
   # develop, test-CI/CD 브랜치는 라즈베리파이 서버로 배포합니다.
   deploy-pi:
-    if: github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/test/#17-CI-CD-test'
+    if: github.ref == 'refs/heads/develop'
     runs-on: ubuntu-latest
     needs: build-and-push-pi
     permissions:
@@ -121,13 +119,12 @@ jobs:
             export COMPOSE_FILE='/home/${{ secrets.PI_USERNAME }}/deploy/compose.blue-green.yml'
             export NGINX_CONFIG_PATH='/etc/nginx/sites-available/ssl.conf'
             chmod +x /home/${{ secrets.PI_USERNAME }}/deploy/deploy.sh
-            docker pull '${{ secrets.PI_DOCKER_IMAGE }}'
             /home/${{ secrets.PI_USERNAME }}/deploy/deploy.sh
             docker image prune -af
 
   # main 브랜치는 GCP 운영 서버용 이미지를 빌드합니다.
   build-and-push-gcp:
-    if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/feature/#15-CI-CD'
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -185,7 +182,7 @@ jobs:
 
   # main 브랜치는 GCP 운영 서버로 배포합니다.
   deploy-gcp:
-    if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/feature/#15-CI-CD'
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     needs: build-and-push-gcp
     permissions:
@@ -235,7 +232,6 @@ jobs:
               export COMPOSE_FILE='/home/${{ secrets.GCP_INSTANCE_USER }}/deploy/compose.blue-green.yml' &&
               export NGINX_CONFIG_PATH='/etc/nginx/sites-available/ssl.conf' &&
               chmod +x /home/${{ secrets.GCP_INSTANCE_USER }}/deploy/deploy.sh &&
-              docker pull '${{ secrets.GCP_DOCKER_IMAGE }}' &&
               /home/${{ secrets.GCP_INSTANCE_USER }}/deploy/deploy.sh &&
               docker image prune -af
             "

--- a/.github/workflows/server_cd.yml
+++ b/.github/workflows/server_cd.yml
@@ -173,7 +173,7 @@ jobs:
 
       # GCP Container Registry 인증을 설정합니다.
       - name: Configure Docker auth for GCP registry
-        run: gcloud auth configure-docker --quiet
+        run: gcloud auth configure-docker asia-northeast3-docker.pkg.dev --quiet
 
       # GCP에 올릴 이미지를 빌드합니다.
       - name: Build Docker image for GCP

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ COPY settings.gradle .
 COPY build.gradle .
 COPY src ./src
 
+RUN sed -i 's/\r$//' gradlew
 RUN chmod +x gradlew
 RUN ./gradlew bootJar --no-daemon
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,13 @@
 FROM eclipse-temurin:21-jdk AS build
 WORKDIR /app
 
-COPY gradlew ./
+COPY gradlew .
 COPY gradle ./gradle
-COPY settings.gradle ./
-COPY build.gradle ./
-RUN chmod +x gradlew
-
+COPY settings.gradle .
+COPY build.gradle .
 COPY src ./src
+
+RUN chmod +x gradlew
 RUN ./gradlew bootJar --no-daemon
 
 FROM eclipse-temurin:21-jre
@@ -15,4 +15,5 @@ WORKDIR /app
 
 COPY --from=build /app/build/libs/*.jar app.jar
 
+EXPOSE 8080 8082
 ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/build.gradle
+++ b/build.gradle
@@ -32,9 +32,12 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity6'
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+<<<<<<< HEAD
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+=======
+>>>>>>> c866200 ([feature] 블루그린 기반 서버 배포 워크플로우 구현)
 
 	// 2. 개발 편의 도구
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'

--- a/build.gradle
+++ b/build.gradle
@@ -32,12 +32,9 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity6'
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
-<<<<<<< HEAD
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
-=======
->>>>>>> c866200 ([feature] 블루그린 기반 서버 배포 워크플로우 구현)
 
 	// 2. 개발 편의 도구
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,0 +1,54 @@
+# 블루/그린 배포
+
+이 디렉터리에는 단일 VM 환경에서 백엔드 블루/그린 배포를 구성할 때 필요한 최소 파일들이 들어 있습니다.
+
+## 파일 설명
+
+- `compose.blue-green.yml`: `app-blue`, `app-green` 컨테이너를 서로 다른 포트로 실행합니다.
+- `deploy.sh`: 현재 비활성 컨테이너를 실행하고 `/actuator/health` 체크 후 nginx 트래픽을 전환하고 이전 컨테이너를 정리합니다.
+- `nginx-app.conf.example`: nginx upstream 설정 예시입니다.
+- `app.env.example`: 운영 서버의 `app.env`를 작성할 때 참고할 수 있는 환경변수 예시입니다.
+
+## 최초 서버 설정
+
+1. 라즈베리파이에 Docker, Docker Compose, nginx, certbot을 설치합니다.
+2. `deploy/compose.blue-green.yml`, `deploy/deploy.sh` 파일을 `/home/<user>/deploy` 로 복사합니다.
+3. `/home/<user>/app.env` 파일을 생성하고 운영 환경변수를 채웁니다.
+4. 필요하면 `deploy/app.env.example` 파일을 템플릿으로 사용합니다.
+5. nginx 설정을 `/etc/nginx/sites-available/ssl.conf` 에 반영하고 활성화합니다.
+6. 라즈베리파이 사용자 계정이 `docker` 명령과 `sudo nginx -s reload` 를 실행할 수 있어야 합니다.
+
+## GitHub Actions 브랜치별 배포
+
+- `develop`, `develop/be`: 라즈베리파이 테스트 서버로 배포
+- `main`: GCP 운영 서버로 배포
+
+## GitHub Actions 시크릿
+
+테스트 서버용 시크릿:
+
+- `TEST_DOCKER_USERNAME`: 테스트용 Docker Registry 계정명
+- `TEST_DOCKER_PASSWORD`: 테스트용 Docker Registry 비밀번호 또는 토큰
+- `TEST_DOCKER_IMAGE`: 테스트 서버에 배포할 이미지 이름
+- `TEST_PI_HOST`: 라즈베리파이 공인 IP 또는 도메인
+- `TEST_PI_USERNAME`: 라즈베리파이 접속 계정명
+- `TEST_PI_SSH_KEY`: GitHub Actions에서 사용할 개인키
+- `TEST_PI_PORT`: SSH 포트 번호
+
+운영 서버용 시크릿:
+
+- `GCP_GCE_SA_KEY`: GCP 서비스 계정 JSON 키
+- `GCP_PROJECT_ID`: GCP 프로젝트 ID
+- `GCP_ZONE`: GCP VM 존
+- `GCP_INSTANCE_NAME`: 운영 VM 이름
+- `GCP_INSTANCE_USER`: 운영 VM 접속 계정명
+- `GCP_DOCKER_IMAGE`: 운영 서버에 배포할 이미지 이름
+
+현재 워크플로우는 테스트 브랜치에서는 `linux/arm64` 이미지로 빌드한 뒤 라즈베리파이에 SSH 배포하고, `main` 브랜치에서는 GCP VM으로 배포합니다.
+
+## 실행 포트
+
+- `app-blue`: 애플리케이션 포트 `8080`, 액추에이터 포트 `8082`
+- `app-green`: 애플리케이션 포트 `8081`, 액추에이터 포트 `8083`
+
+외부 사용자 트래픽은 항상 nginx를 통해 들어오며, nginx upstream은 `127.0.0.1:8080` 또는 `127.0.0.1:8081` 중 하나를 바라보도록 전환됩니다.

--- a/deploy/compose.blue-green.yml
+++ b/deploy/compose.blue-green.yml
@@ -7,6 +7,8 @@ x-app: &app
     TZ: Asia/Seoul
     SERVER_PORT: 8080
     MANAGEMENT_SERVER_PORT: 8082
+  networks:
+    - app-network
 
 services:
   app-blue:
@@ -22,3 +24,8 @@ services:
     ports:
       - "8081:8080"
       - "8083:8082"
+
+networks:
+  app-network:
+    external: true
+    name: ${COMPOSE_SHARED_NETWORK:-dripnote_default}

--- a/deploy/compose.blue-green.yml
+++ b/deploy/compose.blue-green.yml
@@ -1,0 +1,24 @@
+x-app: &app
+  image: ${DOCKER_APP_IMAGE}
+  restart: unless-stopped
+  env_file:
+    - /home/${USERNAME}/app.env
+  environment:
+    TZ: Asia/Seoul
+    SERVER_PORT: 8080
+    MANAGEMENT_SERVER_PORT: 8082
+
+services:
+  app-blue:
+    <<: *app
+    container_name: app-blue
+    ports:
+      - "8080:8080"
+      - "8082:8082"
+
+  app-green:
+    <<: *app
+    container_name: app-green
+    ports:
+      - "8081:8080"
+      - "8083:8082"

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -18,6 +18,14 @@ HEALTH_CHECK_ATTEMPTS="${HEALTH_CHECK_ATTEMPTS:-10}"
 HEALTH_CHECK_DELAY="${HEALTH_CHECK_DELAY:-5}"
 BEFORE_HEALTH_CHECK_DELAY="${BEFORE_HEALTH_CHECK_DELAY:-15}"
 
+run_sudo() {
+    if ! sudo -n "$@" 2>/dev/null; then
+        echo "Passwordless sudo is required for this command: $*"
+        echo "Configure sudoers for ${USER:-the deploy user} before running this script."
+        exit 1
+    fi
+}
+
 health_check() {
     local target_url="$1"
 
@@ -62,9 +70,9 @@ switch_container() {
     fi
 
     echo "Switching nginx upstream from ${previous_port} to ${next_port}"
-    sudo sed -i "s/server 127.0.0.1:${previous_port};/server 127.0.0.1:${next_port};/" "${NGINX_CONFIG_PATH}"
-    sudo nginx -t
-    sudo nginx -s reload
+    run_sudo sed -i "s/server 127.0.0.1:${previous_port};/server 127.0.0.1:${next_port};/" "${NGINX_CONFIG_PATH}"
+    run_sudo nginx -t
+    run_sudo nginx -s reload
 
     echo "Stopping previous container ${previous_container}"
     docker rm -f "${previous_container}" >/dev/null 2>&1 || true

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+
+set -euo pipefail
+
+USERNAME="${USERNAME:?USERNAME is required}"
+DOCKER_APP_IMAGE="${DOCKER_APP_IMAGE:?DOCKER_APP_IMAGE is required}"
+
+COMPOSE_FILE="${COMPOSE_FILE:-/home/${USERNAME}/deploy/compose.blue-green.yml}"
+NGINX_CONFIG_PATH="${NGINX_CONFIG_PATH:-/etc/nginx/sites-available/ssl.conf}"
+
+BLUE_PORT=8080
+GREEN_PORT=8081
+
+BLUE_HEALTH_CHECK_URL="http://127.0.0.1:8082/actuator/health"
+GREEN_HEALTH_CHECK_URL="http://127.0.0.1:8083/actuator/health"
+
+HEALTH_CHECK_ATTEMPTS="${HEALTH_CHECK_ATTEMPTS:-10}"
+HEALTH_CHECK_DELAY="${HEALTH_CHECK_DELAY:-5}"
+BEFORE_HEALTH_CHECK_DELAY="${BEFORE_HEALTH_CHECK_DELAY:-15}"
+
+health_check() {
+    local target_url="$1"
+
+    echo "Performing health check for ${target_url}"
+
+    for attempt in $(seq 1 "${HEALTH_CHECK_ATTEMPTS}"); do
+        local response
+        response=$(curl -s -o /dev/null -w "%{http_code}" "${target_url}" || true)
+
+        if [ "${response}" = "200" ]; then
+            echo "Health check passed (${attempt}/${HEALTH_CHECK_ATTEMPTS})"
+            return 0
+        fi
+
+        echo "Health check failed (${attempt}/${HEALTH_CHECK_ATTEMPTS}), response=${response}"
+        sleep "${HEALTH_CHECK_DELAY}"
+    done
+
+    return 1
+}
+
+switch_container() {
+    local previous_container="$1"
+    local previous_port="$2"
+    local next_container="$3"
+    local next_port="$4"
+    local health_check_url="$5"
+
+    echo "Pulling latest image ${DOCKER_APP_IMAGE}"
+    docker pull "${DOCKER_APP_IMAGE}"
+
+    echo "Starting ${next_container}"
+    docker compose -f "${COMPOSE_FILE}" up -d "${next_container}"
+
+    echo "Waiting ${BEFORE_HEALTH_CHECK_DELAY}s for startup"
+    sleep "${BEFORE_HEALTH_CHECK_DELAY}"
+
+    if ! health_check "${health_check_url}"; then
+        echo "Health check failed for ${next_container}, rolling back"
+        docker compose -f "${COMPOSE_FILE}" stop "${next_container}"
+        exit 1
+    fi
+
+    echo "Switching nginx upstream from ${previous_port} to ${next_port}"
+    sudo sed -i "s/server 127.0.0.1:${previous_port};/server 127.0.0.1:${next_port};/" "${NGINX_CONFIG_PATH}"
+    sudo nginx -t
+    sudo nginx -s reload
+
+    echo "Stopping previous container ${previous_container}"
+    docker rm -f "${previous_container}" >/dev/null 2>&1 || true
+}
+
+if docker ps --format '{{.Names}}' | grep -qx 'app-green'; then
+    echo "### GREEN -> BLUE ###"
+    switch_container "app-green" "${GREEN_PORT}" "app-blue" "${BLUE_PORT}" "${BLUE_HEALTH_CHECK_URL}"
+else
+    echo "### BLUE -> GREEN ###"
+    switch_container "app-blue" "${BLUE_PORT}" "app-green" "${GREEN_PORT}" "${GREEN_HEALTH_CHECK_URL}"
+fi
+
+echo "Deployment completed successfully"

--- a/deploy/nginx-app.conf.example
+++ b/deploy/nginx-app.conf.example
@@ -1,0 +1,32 @@
+# Redirect HTTP traffic to HTTPS.
+server {
+    listen 80 default_server;
+    listen [::]:80 default_server;
+    server_name your-domain.example;
+
+    return 301 https://$host$request_uri;
+}
+
+upstream app {
+    server 127.0.0.1:8080;
+}
+
+server {
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
+    server_name your-domain.example;
+
+    ssl_certificate /etc/letsencrypt/live/your-domain.example/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/your-domain.example/privkey.pem;
+    include /etc/letsencrypt/options-ssl-nginx.conf;
+    ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
+
+    location / {
+        proxy_pass http://app;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,6 @@
 services:
   app:
+<<<<<<< HEAD
     image: le3560/dripnote-backend:0.0.1   # Docker Hub에서 가져올 백엔드 이미지
     ports:
       - "8080:8080"                        # 호스트의 8080 포트를 컨테이너 8080에 연결
@@ -36,6 +37,85 @@ services:
   redis:
     image: redis:7-alpine                   # 공식 Redis 경량 이미지 사용
     restart: unless-stopped                 # 수동 중지 전까지 자동 재시작
+=======
+    # 백엔드 앱 이미지
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: le3560/dripnote-backend:0.0.1
 
+    # 로컬에서 백엔드 접속 포트
+    ports:
+      - "8080:8080"
+
+    # 앱 실행에 필요한 환경변수
+    env_file:
+      - .env
+
+    # db가 healthy 상태가 된 뒤 app 시작
+    depends_on:
+      db:
+        condition: service_healthy
+      redis:
+        condition: service_started
+
+    restart: unless-stopped
+
+  db:
+    # MySQL 전용 이미지
+    build:
+      context: ./mysql
+      dockerfile: Dockerfile
+    image: le3560/dripnote-mysql:0.0.1
+
+    # MySQL 컨테이너 초기 설정
+    # 여기 값은 .env에서 읽음
+    environment:
+      MYSQL_DATABASE: ${MYSQL_DATABASE}
+      MYSQL_USER: ${MYSQL_USER}
+      MYSQL_PASSWORD: ${MYSQL_PASSWORD}
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
+      TZ: Asia/Seoul
+
+    ports:
+      - "3307:3306"
+
+    # 문자셋/콜레이션 설정
+    command:
+      - --character-set-server=utf8mb4
+      - --collation-server=utf8mb4_unicode_ci
+
+    # MySQL이 실제로 응답 가능한지 확인
+    # app은 이 healthcheck가 통과된 뒤 시작됨
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "mysqladmin ping -h localhost -uroot -p$${MYSQL_ROOT_PASSWORD} || exit 1",
+        ]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 30s
+
+    # DB 데이터 영속화
+    # 컨테이너를 지워도 volume이 남아 있으면 데이터 유지
+    volumes:
+      - mysql_data:/var/lib/mysql
+
+    restart: unless-stopped
+>>>>>>> c866200 ([feature] 블루그린 기반 서버 배포 워크플로우 구현)
+
+  redis:
+    image: redis:7-alpine
+    restart: unless-stopped
+    ports:
+      - "6379:6379"
+
+# MySQL 데이터 저장용 named volume
 volumes:
+<<<<<<< HEAD
   mysql_data:                               # MySQL 영구 저장용 Docker 볼륨
+=======
+  mysql_data:
+>>>>>>> c866200 ([feature] 블루그린 기반 서버 배포 워크플로우 구현)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,121 +1,45 @@
 services:
   app:
-<<<<<<< HEAD
-    image: le3560/dripnote-backend:0.0.1   # Docker Hub에서 가져올 백엔드 이미지
+    image: le3560/dripnote-backend:0.0.1 # Docker Hub에서 가져올 백엔드 이미지
     ports:
-      - "8080:8080"                        # 호스트의 8080 포트를 컨테이너 8080에 연결
+      - "8080:8080" # 호스트의 8080 포트를 컨테이너 8080에 연결
     env_file:
-      - .env                               # 백엔드 실행에 필요한 환경변수 파일 로드
+      - .env # 백엔드 실행에 필요한 환경변수 파일 로드
     depends_on:
       db:
-        condition: service_healthy         # MySQL이 healthcheck 통과 후 app 시작
+        condition: service_healthy # MySQL이 healthcheck 통과 후 app 시작
       redis:
-        condition: service_started         # Redis 컨테이너가 시작된 뒤 app 시작
-    restart: unless-stopped                # 수동으로 중지하지 않는 한 재시작 시 자동 복구
+        condition: service_started # Redis 컨테이너가 시작된 뒤 app 시작
+    restart: unless-stopped # 수동으로 중지하지 않는 한 재시작 시 자동 복구
 
   db:
-    image: le3560/dripnote-mysql:0.0.1     # Docker Hub에서 가져올 MySQL 이미지
+    image: le3560/dripnote-mysql:0.0.1 # Docker Hub에서 가져올 MySQL 이미지
     environment:
-      MYSQL_DATABASE: ${MYSQL_DATABASE}            # 생성할 기본 데이터베이스 이름
-      MYSQL_USER: ${MYSQL_USER}                    # 일반 사용자 계정 이름
-      MYSQL_PASSWORD: ${MYSQL_PASSWORD}            # 일반 사용자 비밀번호
-      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}  # root 계정 비밀번호
-      TZ: Asia/Seoul                               # 컨테이너 시간대를 한국 시간으로 설정
+      MYSQL_DATABASE: ${MYSQL_DATABASE} # 생성할 기본 데이터베이스 이름
+      MYSQL_USER: ${MYSQL_USER} # 일반 사용자 계정 이름
+      MYSQL_PASSWORD: ${MYSQL_PASSWORD} # 일반 사용자 비밀번호
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD} # root 계정 비밀번호
+      TZ: Asia/Seoul # 컨테이너 시간대를 한국 시간으로 설정
     command:
-      - --character-set-server=utf8mb4     # MySQL 기본 문자셋을 utf8mb4로 설정
+      - --character-set-server=utf8mb4 # MySQL 기본 문자셋을 utf8mb4로 설정
       - --collation-server=utf8mb4_unicode_ci # MySQL 기본 정렬 규칙 설정
     healthcheck:
-      test: ["CMD-SHELL", "mysqladmin ping -h localhost -uroot -p$${MYSQL_ROOT_PASSWORD} || exit 1"] # MySQL 응답 여부 확인
-      interval: 10s                         # 10초마다 healthcheck 실행
-      timeout: 5s                           # 5초 안에 응답 없으면 실패 처리
-      retries: 10                           # 10번 연속 실패하면 unhealthy 처리
-      start_period: 30s                     # 시작 후 30초 동안은 준비 시간으로 간주
-    volumes:
-      - mysql_data:/var/lib/mysql           # MySQL 데이터 파일을 볼륨에 저장해서 재시작 후에도 유지
-    restart: unless-stopped                 # 수동 중지 전까지 자동 재시작
-
-  redis:
-    image: redis:7-alpine                   # 공식 Redis 경량 이미지 사용
-    restart: unless-stopped                 # 수동 중지 전까지 자동 재시작
-=======
-    # 백엔드 앱 이미지
-    build:
-      context: .
-      dockerfile: Dockerfile
-    image: le3560/dripnote-backend:0.0.1
-
-    # 로컬에서 백엔드 접속 포트
-    ports:
-      - "8080:8080"
-
-    # 앱 실행에 필요한 환경변수
-    env_file:
-      - .env
-
-    # db가 healthy 상태가 된 뒤 app 시작
-    depends_on:
-      db:
-        condition: service_healthy
-      redis:
-        condition: service_started
-
-    restart: unless-stopped
-
-  db:
-    # MySQL 전용 이미지
-    build:
-      context: ./mysql
-      dockerfile: Dockerfile
-    image: le3560/dripnote-mysql:0.0.1
-
-    # MySQL 컨테이너 초기 설정
-    # 여기 값은 .env에서 읽음
-    environment:
-      MYSQL_DATABASE: ${MYSQL_DATABASE}
-      MYSQL_USER: ${MYSQL_USER}
-      MYSQL_PASSWORD: ${MYSQL_PASSWORD}
-      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
-      TZ: Asia/Seoul
-
-    ports:
-      - "3307:3306"
-
-    # 문자셋/콜레이션 설정
-    command:
-      - --character-set-server=utf8mb4
-      - --collation-server=utf8mb4_unicode_ci
-
-    # MySQL이 실제로 응답 가능한지 확인
-    # app은 이 healthcheck가 통과된 뒤 시작됨
-    healthcheck:
-      test:
-        [
+      test: [
           "CMD-SHELL",
           "mysqladmin ping -h localhost -uroot -p$${MYSQL_ROOT_PASSWORD} || exit 1",
-        ]
-      interval: 10s
-      timeout: 5s
-      retries: 10
-      start_period: 30s
-
-    # DB 데이터 영속화
-    # 컨테이너를 지워도 volume이 남아 있으면 데이터 유지
+        ] # MySQL 응답 여부 확인
+      interval: 10s # 10초마다 healthcheck 실행
+      timeout: 5s # 5초 안에 응답 없으면 실패 처리
+      retries: 10 # 10번 연속 실패하면 unhealthy 처리
+      start_period: 30s # 시작 후 30초 동안은 준비 시간으로 간주
     volumes:
-      - mysql_data:/var/lib/mysql
-
-    restart: unless-stopped
->>>>>>> c866200 ([feature] 블루그린 기반 서버 배포 워크플로우 구현)
+      - mysql_data:/var/lib/mysql # MySQL 데이터 파일을 볼륨에 저장해서 재시작 후에도 유지
+    restart: unless-stopped # 수동 중지 전까지 자동 재시작
 
   redis:
-    image: redis:7-alpine
-    restart: unless-stopped
-    ports:
-      - "6379:6379"
+    image: redis:7-alpine # 공식 Redis 경량 이미지 사용
+    restart: unless-stopped # 수동 중지 전까지 자동 재시작
 
 # MySQL 데이터 저장용 named volume
 volumes:
-<<<<<<< HEAD
-  mysql_data:                               # MySQL 영구 저장용 Docker 볼륨
-=======
-  mysql_data:
->>>>>>> c866200 ([feature] 블루그린 기반 서버 배포 워크플로우 구현)
+  mysql_data: # MySQL 영구 저장용 Docker 볼륨

--- a/src/main/java/dripnote/security/config/SecurityConfig.java
+++ b/src/main/java/dripnote/security/config/SecurityConfig.java
@@ -61,6 +61,8 @@ public class SecurityConfig {
                                 "/swagger-ui/**",
                                 "/api-docs",
                                 "/api-docs/**"
+                                "/actuator/health",
+                                "/actuator/health/**",
 
                         ).permitAll()
                         .requestMatchers(


### PR DESCRIPTION
## #️⃣연관된 이슈

> #15 

## 📝작업 내용

> main / develop 분기 별 CI/CD 구축
> dev : 개인 라즈베리 파이 서버에 개발용 테스팅 서버 구축 ( docker image는 dripnote doc hub에 구성 )
> main : gcp 서버로 운영 서버 구축 ( docker image는 gcp Artifact Registry에 구성 )
> blue - green 전환 시 health check 하기 위하여 Security 파일 수정하였음

## 중점적으로 리뷰받고 싶은 부분
> deploy, server.cd 파일

## 논의하고 싶은 부분

> 포트 번호는 제 임의로 했는데 상관이 있을지요


