### PR TITLE
[refactor] OAuth RT Response 구조 변경

### DIFF
--- a/src/main/java/baristation/common/cookie/CookieUtil.java
+++ b/src/main/java/baristation/common/cookie/CookieUtil.java
@@ -1,0 +1,40 @@
+package baristation.common.cookie;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseCookie;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+
+@Component
+public class CookieUtil {
+    private static final String REFRESH_TOKEN_COOKIE_NAME = "refreshToken";
+
+    @Value("${jwt.refresh_expiration_time}")
+    private Duration refreshExp;
+
+    // refreshToken 저장용 쿠키 생성
+    public ResponseCookie createRefreshTokenCookie(String refreshToken) {
+        return ResponseCookie.from(REFRESH_TOKEN_COOKIE_NAME, refreshToken)
+                .httpOnly(true)
+                .secure(true)
+                .sameSite("None")
+                .path("/")
+                .maxAge(refreshExp)
+                .build();
+    }
+
+    /**
+     * refreshToken 쿠키 삭제용 Set-Cookie 값 생성
+     * 쿠키 삭제는 생성 때와 같은 path를 사용하고 maxAge를 0으로 내려야 브라우저가 제거함
+     */
+    public ResponseCookie deleteRefreshTokenCookie() {
+        return ResponseCookie.from(REFRESH_TOKEN_COOKIE_NAME, "")
+                .httpOnly(true)
+                .secure(true)
+                .sameSite("None")
+                .path("/")
+                .maxAge(0)
+                .build();
+    }
+}

--- a/src/main/java/baristation/security/config/SecurityConfig.java
+++ b/src/main/java/baristation/security/config/SecurityConfig.java
@@ -78,7 +78,7 @@ public class SecurityConfig {
         configuration.setAllowedOrigins(Collections.singletonList(frontendBaseUrl)); // 리액트 주소 허용
         configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"));
         configuration.setAllowedHeaders(Collections.singletonList("*"));
-        configuration.setAllowCredentials(false); // 쿠키 미사용 전제
+        configuration.setAllowCredentials(true); // 쿠키를 사용하여 true로 수정
 
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         source.registerCorsConfiguration("/**", configuration);

--- a/src/main/java/baristation/security/handler/OAuth2SuccessHandler.java
+++ b/src/main/java/baristation/security/handler/OAuth2SuccessHandler.java
@@ -1,10 +1,11 @@
 package baristation.security.handler;
 
+import baristation.common.cookie.CookieUtil;
 import baristation.common.exception.CustomException;
 import baristation.common.exception.ErrorCode;
 import baristation.common.redis.RedisService;
 import baristation.security.jwt.JwtTokenProvider;
-import baristation.security.payload.dto.TokenResponse;
+import baristation.security.payload.dto.TokenPair;
 import baristation.user.domain.User;
 import baristation.user.payload.dto.oauth.GoogleUserInfoDTO;
 import baristation.user.payload.dto.oauth.KakaoUserInfoDTO;
@@ -17,6 +18,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
 import org.springframework.security.oauth2.core.user.OAuth2User;
@@ -31,10 +33,10 @@ import java.util.Map;
 @Component
 @RequiredArgsConstructor
 public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
-    // OAuth2 로그인 성공 시 처리할 로직
     private final JwtTokenProvider jwtTokenProvider;
     private final UserRepository userRepository;
     private final RedisService redisService;
+    private final CookieUtil cookieUtil;
 
     @Value("${app.frontend.base-url}")
     private String frontendBaseUrl;
@@ -42,16 +44,12 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
                                         Authentication authentication) throws IOException, ServletException {
-
-
-        // 기존 OAuth2 토큰 정보에서 provider와 사용자 정보를 추출.
         OAuth2AuthenticationToken oauth2Token = (OAuth2AuthenticationToken) authentication;
         String provider = oauth2Token.getAuthorizedClientRegistrationId();
         OAuth2User oauth2User = (OAuth2User) authentication.getPrincipal();
 
         Map<String, Object> attributes = oauth2User.getAttributes();
 
-        // provider에 맞는 oauthDTO 받기.
         OAuth2UserInfo userInfo = null;
         if (provider.equals("google")) {
             userInfo = GoogleUserInfoDTO.from(attributes);
@@ -62,19 +60,20 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
         } else {
             throw new CustomException(ErrorCode.INVALID_REQUEST);
         }
-        User user = userRepository.findByProviderAndProviderId(userInfo.getProvider(), userInfo.getProviderId())
-                .orElseThrow(() ->
-                    new CustomException(ErrorCode.USER_NOT_FOUND));
 
-        TokenResponse tokenResponse = jwtTokenProvider.createTokenSet(user);
-        redisService.setRefreshToken(String.valueOf(user.getUserId()), tokenResponse.refreshToken());
-        // 리액트로 보낼 url 생성
+        User user = userRepository.findByProviderAndProviderId(userInfo.getProvider(), userInfo.getProviderId())
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        TokenPair tokenPair = jwtTokenProvider.createTokenSet(user);
+        response.addHeader(HttpHeaders.SET_COOKIE, cookieUtil.createRefreshTokenCookie(tokenPair.refreshToken()).toString());
+
+        redisService.setRefreshToken(String.valueOf(user.getUserId()), tokenPair.refreshToken());
+
         String targetUrl = UriComponentsBuilder.fromUriString(frontendBaseUrl)
                 .build().toUriString();
 
         log.info("로그인 성공! JWT 발급 완료. targetUrl: {}", targetUrl);
 
-        // url로 리다이렉트
         getRedirectStrategy().sendRedirect(request, response, targetUrl);
     }
 }

--- a/src/main/java/baristation/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/baristation/security/jwt/JwtTokenProvider.java
@@ -3,7 +3,7 @@ package baristation.security.jwt;
 import baristation.common.redis.RedisService;
 import baristation.common.exception.CustomException;
 import baristation.common.exception.ErrorCode;
-import baristation.security.payload.dto.TokenResponse;
+import baristation.security.payload.dto.TokenPair;
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.security.Keys;
 import lombok.extern.slf4j.Slf4j;
@@ -47,11 +47,11 @@ public class JwtTokenProvider {
     /**
      * 외부에서 호출 가능하도록 createTokenSet 구현
      */
-    public TokenResponse createTokenSet(User user) {
+    public TokenPair createTokenSet(User user) {
         String accessToken = generateAccessToken(user);
         String refreshToken = generateRefreshToken(user);
 
-        return TokenResponse.builder()
+        return TokenPair.builder()
                 .accessToken(accessToken)
                 .refreshToken(refreshToken)
                 .tokenType(TOKEN_TYPE_BEARER)

--- a/src/main/java/baristation/security/payload/dto/TokenPair.java
+++ b/src/main/java/baristation/security/payload/dto/TokenPair.java
@@ -3,8 +3,9 @@ package baristation.security.payload.dto;
 import lombok.Builder;
 
 @Builder
-public record TokenResponse(
+public record TokenPair(
     String accessToken,
+    String refreshToken,
     String tokenType // "Bearer"
 ) {
 }

--- a/src/main/java/baristation/user/controller/UserController.java
+++ b/src/main/java/baristation/user/controller/UserController.java
@@ -1,35 +1,58 @@
 package baristation.user.controller;
 
+import baristation.common.cookie.CookieUtil;
 import baristation.common.payload.response.ApiResponse;
+import baristation.security.payload.dto.TokenPair;
 import baristation.security.payload.dto.TokenResponse;
 import baristation.user.payload.dto.UserUpdateRequest;
 import baristation.user.service.UserService;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.CookieValue;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/auth")
 @RequiredArgsConstructor
 public class UserController {
     private final UserService userService;
+    private final CookieUtil cookieUtil;
 
-    // 토큰 재발급
     @PostMapping("/refresh")
     public ResponseEntity<ApiResponse<TokenResponse>> refreshUser(
-            @RequestHeader(value = "Refresh-Token", required = false) String refreshToken) {
-        TokenResponse newTokenResponse = userService.refresh(refreshToken);
-        return ApiResponse.ok(newTokenResponse);
+            @CookieValue(value = "refreshToken", required = false) String refreshToken,
+            HttpServletResponse response) {
+        TokenPair newTokenPair = userService.refresh(refreshToken);
+
+        // 쿠키를 생성하여 response 헤더에 저장
+        response.addHeader(HttpHeaders.SET_COOKIE, cookieUtil.createRefreshTokenCookie(newTokenPair.refreshToken()).toString());
+
+        TokenResponse tokenResponse = TokenResponse.builder()
+                .accessToken(newTokenPair.accessToken())
+                .tokenType(newTokenPair.tokenType())
+                .build();
+
+        return ApiResponse.ok(tokenResponse);
     }
 
     @PostMapping("/logout")
-    public ResponseEntity<ApiResponse<Void>> logout(HttpServletRequest request) {
+    public ResponseEntity<ApiResponse<Void>> logout(HttpServletRequest request, HttpServletResponse response) {
         userService.logout(request);
+
+        // refreshToken 쿠키를 삭제하기위해 maxAge 0으로 설정하고 response 헤더에 저장
+        response.addHeader(HttpHeaders.SET_COOKIE, cookieUtil.deleteRefreshTokenCookie().toString());
+
         return ApiResponse.ok();
     }
 
-    // 회원 정보 수정
     @PatchMapping("/update")
     public ResponseEntity<ApiResponse<Void>> updateUserInfo(
             HttpServletRequest request,
@@ -37,10 +60,13 @@ public class UserController {
         userService.updateUser(request, updateRequest);
         return ApiResponse.ok();
     }
-    // 회원 탈퇴
+
     @DeleteMapping("/delete")
-    public ResponseEntity<ApiResponse<Void>> deleteAccount(HttpServletRequest request) {
+    public ResponseEntity<ApiResponse<Void>> deleteAccount(HttpServletRequest request, HttpServletResponse response) {
         userService.deleteUser(request);
+
+        // refreshToken 쿠키를 삭제하기위해 maxAge 0으로 설정하고 response 헤더에 저장
+        response.addHeader(HttpHeaders.SET_COOKIE, cookieUtil.deleteRefreshTokenCookie().toString());
         return ApiResponse.ok();
     }
 }

--- a/src/main/java/baristation/user/service/UserService.java
+++ b/src/main/java/baristation/user/service/UserService.java
@@ -4,7 +4,7 @@ import baristation.common.exception.CustomException;
 import baristation.common.exception.ErrorCode;
 import baristation.common.redis.RedisService;
 import baristation.security.jwt.JwtTokenProvider;
-import baristation.security.payload.dto.TokenResponse;
+import baristation.security.payload.dto.TokenPair;
 import jakarta.servlet.http.HttpServletRequest;
 import baristation.user.domain.User;
 import baristation.user.payload.dto.UserUpdateRequest;
@@ -41,7 +41,7 @@ public class UserService {
         log.info("로그아웃 완료. userId: {}", userIdText);
     }
 
-    public TokenResponse refresh(String refreshToken) {
+    public TokenPair refresh(String refreshToken) {
         // null/blank 체크
         if (!StringUtils.hasText(refreshToken)) {
             throw new CustomException(ErrorCode.REFRESH_TOKEN_REQUIRED);
@@ -62,10 +62,10 @@ public class UserService {
         User user = userRepository.getUserByUserId(userId)
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
-        TokenResponse newTokenResponse = jwtTokenProvider.createTokenSet(user);
-        redisService.setRefreshToken(userIdText, newTokenResponse.refreshToken());
+        TokenPair newTokenPair = jwtTokenProvider.createTokenSet(user);
+        redisService.setRefreshToken(userIdText, newTokenPair.refreshToken());
         log.info("회원 refresh 완료. userId: {}", userIdText);
-        return newTokenResponse;
+        return newTokenPair;
     }
 
     public void deleteUser(HttpServletRequest request) {


### PR DESCRIPTION
## #️⃣연관된 이슈

> #32 

## 📝작업 내용

>    TokenPair와 TokenResponse로 내부 DTO와 외부 DTO 분리
>    CookieUtil을 공동 컴포넌트로 만들어서 refreshToken 쿠키 생성 / 삭제 로직을 한 곳으로 분리하여 사용 
      (추후 path 변경이 있을 수 도 있으니 사용성을 위함)
>    refresh 로직이 새 TokenPair를 만들고 Redis refreshToken도 갱신하도록 변경
>    refreshToken을 헤더가 아니라 쿠키에서 읽도록 변경
>    refresh 성공 시 새 refreshToken 쿠키 재발급
>    logout / delete 시 refreshToken 쿠키 삭제
<img width="750" height="205" alt="image" src="https://github.com/user-attachments/assets/1eec3dcb-c5bc-4b26-b7d2-7872e65f6d7e" />

백엔드 서버측에서는 refreshToken이 Cookie로 잘 들어오는 것을 확인하였습니다.

<img width="1415" height="528" alt="image" src="https://github.com/user-attachments/assets/24c287ba-1d13-403b-9809-101a43c96526" />

발행된 refreshToken으로 accessToken도 잘 반환되는 것을 확인하였습니다.

## 🫡 참고사항

프론트측에서 아직 확인이 불가능하여 북마크 및 원두 기능 테스트가 완료되면 다시 테스트 하도록 하겠습니다!