### PR TITLE
[feature] 클래스 목록 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,6 @@
 plugins {
 	id 'java'
+	id 'idea'
 	id 'org.springframework.boot' version '4.0.4'
 	id 'io.spring.dependency-management' version '1.1.7'
 }
@@ -64,18 +65,20 @@ dependencies {
 	testImplementation 'com.h2database:h2'
 }
 
-def querydslDir = "build/generated/querydsl"
+def querydslDir = layout.buildDirectory.dir("generated/sources/annotationProcessor/java/main").get().asFile
 
 sourceSets {
-	main.java.srcDirs += file(querydslDir)
+	main.java.srcDirs += querydslDir
 }
 
 tasks.withType(JavaCompile).configureEach {
-	options.getGeneratedSourceOutputDirectory().set(file(querydslDir))
+	options.getGeneratedSourceOutputDirectory().set(querydslDir)
 }
 
-clean.doLast {
-	file(querydslDir).deleteDir()
+idea {
+	module {
+		generatedSourceDirs += querydslDir
+	}
 }
 
 tasks.named('test') {

--- a/src/main/java/baristation/common/exception/ErrorCode.java
+++ b/src/main/java/baristation/common/exception/ErrorCode.java
@@ -21,16 +21,10 @@ public enum ErrorCode {
     TOO_LONG_INTRODUCTION(HttpStatus.BAD_REQUEST, "600-10", "소개는 최대 24글자까지 입력할 수 있습니다."),
     CLUB_NAME_ALREADY_EXISTS(HttpStatus.CONFLICT, "600-11", "이미 사용 중인 동아리 이름입니다."),
 
-    // 601xx: Class 관련 오류
-    IMAGE_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "601-1", "이미지 업로드에 실패하였습니다."),
-    FILE_NOT_FOUND(HttpStatus.NOT_FOUND, "601-2", "이미지 파일을 찾을 수 없습니다."),
-    IMAGE_DELETE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "601-4", "이미지 삭제에 실패하였습니다"),
-    KOREAN_FILE_NAME(HttpStatus.INTERNAL_SERVER_ERROR, "601-5", "파일명의 한국어를 인코딩할 수 없습니다."),
-    FILE_TRANSFER_ERROR(HttpStatus.BAD_REQUEST, "601-6", "파일을 올바른 형식으로 변경할 수 없습니다."),
-    UNSUPPORTED_FILE_TYPE(HttpStatus.BAD_REQUEST, "601-7", "파일의 확장자가 올바르지 않습니다."),
-    INVALID_FILE_URL(HttpStatus.BAD_REQUEST, "601-8", "올바르지 않은 파일 URL입니다."),
-    FILE_DELETE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "601-9", "파일 삭제에 실패하였습니다."),
-    WEBHOOK_INVALID_REQUEST(HttpStatus.BAD_REQUEST, "601-11", "웹훅 요청이 올바르지 않습니다."),
+    // 601xx: Lesson 관련 오류
+    LESSON_SEARCH_INVALID_REQUEST(HttpStatus.BAD_REQUEST, "601-1", "클래스 검색 요청이 올바르지 않습니다."), // 601-1 이형동: 잘못된 검색 요청
+    LESSON_SEARCH_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "601-2", "클래스 검색 중 오류가 발생했습니다."), // 601-2 이형동: 검색 처리 중 예상 밖의 서버 오류 (서버 로그 확인)
+    LESSON_SEARCH_MAPPING_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "601-3", "클래스 검색 결과를 응답으로 변환할 수 없습니다."), // 601-3 이형동: lesson이 없거나 hostUser가 없을 때
 
      // 700xx: 사용자/권한 관련 오류
      USER_INVALID_LOGIN(HttpStatus.BAD_REQUEST, "700-4", "올바르지 않은 로그인"),

--- a/src/main/java/baristation/lesson/controller/LessonController.java
+++ b/src/main/java/baristation/lesson/controller/LessonController.java
@@ -1,0 +1,47 @@
+package baristation.lesson.controller;
+
+import baristation.common.logging.TraceIdUtil;
+import baristation.common.payload.response.ApiResponse;
+import baristation.common.payload.response.PageResponse;
+import baristation.lesson.payload.dto.LessonDTO;
+import baristation.lesson.payload.dto.LessonDetailDTO;
+import baristation.lesson.payload.request.LessonSearchRequest;
+import baristation.lesson.service.LessonService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@Slf4j
+@RequestMapping("/api/lessons")
+public class LessonController {
+    private final LessonService lessonService;
+
+    /**
+     * 클래스 검색 요청 파라미터와 페이징 정보를 받아 검색 결과를 반환한다.
+     */
+    @GetMapping("/search")
+    public ResponseEntity<ApiResponse<PageResponse<LessonDTO>>> searchLessons(
+            @ModelAttribute LessonSearchRequest request,
+            @PageableDefault(size = 12) Pageable pageable
+    ) {
+        log.info("[Lesson] searchLessons start. page={}, size={}, keyword={}, region={}, difficulty={}, traceId={}",
+                pageable.getPageNumber(), pageable.getPageSize(), request.keyword(), request.region(), request.difficulty(), TraceIdUtil.getTraceId());
+        PageResponse<LessonDTO> response = lessonService.searchLessons(request, pageable);
+        log.info("[Lesson] searchLessons done. contentSize={}, totalElements={}, traceId={}",
+                response.content().size(), response.totalElements(), TraceIdUtil.getTraceId());
+        return ApiResponse.ok(response);
+    }
+
+    /**
+     * 클래스 상세 정보를 조회한다. 상세 구현은 LessonService 구현 상태를 따른다.
+     */
+    @GetMapping("/{lessonId}")
+    public ResponseEntity<ApiResponse<LessonDetailDTO>> getLessonDetail(@PathVariable Long lessonId) {
+        return ApiResponse.ok(lessonService.getLessonDetail(lessonId));
+    }
+}

--- a/src/main/java/baristation/lesson/controller/LessonController.java
+++ b/src/main/java/baristation/lesson/controller/LessonController.java
@@ -29,8 +29,8 @@ public class LessonController {
             @ModelAttribute LessonSearchRequest request,
             @PageableDefault(size = 12) Pageable pageable
     ) {
-        log.info("[Lesson] searchLessons start. page={}, size={}, keyword={}, region={}, difficulty={}, traceId={}",
-                pageable.getPageNumber(), pageable.getPageSize(), request.keyword(), request.region(), request.difficulty(), TraceIdUtil.getTraceId());
+        log.info("[Lesson] searchLessons start. page={}, size={}, keyword={}, category={}, region={}, difficulty={}, traceId={}",
+                pageable.getPageNumber(), pageable.getPageSize(), request.keyword(), request.category(), request.region(), request.difficulty(), TraceIdUtil.getTraceId());
         PageResponse<LessonDTO> response = lessonService.searchLessons(request, pageable);
         log.info("[Lesson] searchLessons done. contentSize={}, totalElements={}, traceId={}",
                 response.content().size(), response.totalElements(), TraceIdUtil.getTraceId());

--- a/src/main/java/baristation/lesson/domain/Lesson.java
+++ b/src/main/java/baristation/lesson/domain/Lesson.java
@@ -10,11 +10,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.CreationTimestamp;
-import org.hibernate.annotations.UpdateTimestamp;
 
 import java.math.BigDecimal;
-import java.time.LocalDateTime;
 
 @Getter
 @Builder

--- a/src/main/java/baristation/lesson/domain/LessonCurriculum.java
+++ b/src/main/java/baristation/lesson/domain/LessonCurriculum.java
@@ -1,8 +1,10 @@
 package baristation.lesson.domain;
 
 import jakarta.persistence.*;
+import lombok.Getter;
 
 @Entity
+@Getter
 @Table(name = "lesson_curriculum")
 public class LessonCurriculum {
 

--- a/src/main/java/baristation/lesson/domain/LessonSchedule.java
+++ b/src/main/java/baristation/lesson/domain/LessonSchedule.java
@@ -8,8 +8,6 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.CreationTimestamp;
-import org.hibernate.annotations.UpdateTimestamp;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -33,7 +31,7 @@ public class LessonSchedule extends BaseTimeEntity {
     private Lesson lesson;
 
     @Column(name = "lesson_date", nullable = false)
-    private LocalDate lessonDate;
+    private LocalDateTime lessonDate;
 
     @Column(name = "start_time", nullable = false)
     private LocalTime startTime;

--- a/src/main/java/baristation/lesson/domain/Region.java
+++ b/src/main/java/baristation/lesson/domain/Region.java
@@ -1,0 +1,14 @@
+package baristation.lesson.domain;
+
+import jakarta.persistence.*;
+
+@Entity
+public class Region {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "region_id")
+    private Long regionId;
+
+    @Column(name = "name")
+    private String name;
+}

--- a/src/main/java/baristation/lesson/enums/LessonCategory.java
+++ b/src/main/java/baristation/lesson/enums/LessonCategory.java
@@ -1,6 +1,38 @@
 package baristation.lesson.enums;
 
+import baristation.common.exception.CustomException;
+import baristation.common.exception.ErrorCode;
+
 public enum LessonCategory {
-    HOBBY,
-    CERTYFICATE
+    HOBBY("취미"),
+    CERTIFICATE("자격증");
+
+    private final String label;
+
+    LessonCategory(String label) {
+        this.label = label;
+    }
+
+    public String label() {
+        return label;
+    }
+
+    public static LessonCategory from(String value) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+
+        String normalized = value.trim();
+
+        for (LessonCategory category : values()) {
+            if (
+                    category.name().equalsIgnoreCase(normalized)
+                            || category.label.equals(normalized)
+            ) {
+                return category;
+            }
+        }
+
+        throw new CustomException(ErrorCode.LESSON_SEARCH_INVALID_REQUEST);
+    }
 }

--- a/src/main/java/baristation/lesson/enums/Region.java
+++ b/src/main/java/baristation/lesson/enums/Region.java
@@ -32,6 +32,7 @@ public enum Region {
         return label;
     }
 
+    // 서울" 같은 화면 표시명을 보내면 label을 기준으로 매칭
     public static Region from(String value) {
         if (value == null || value.isBlank()) {
             return null;

--- a/src/main/java/baristation/lesson/enums/Region.java
+++ b/src/main/java/baristation/lesson/enums/Region.java
@@ -1,0 +1,49 @@
+package baristation.lesson.enums;
+
+import baristation.common.exception.CustomException;
+import baristation.common.exception.ErrorCode;
+
+public enum Region {
+    SEOUL("서울"),
+    GYEONGGI("경기"),
+    INCHEON("인천"),
+    BUSAN("부산"),
+    DAEGU("대구"),
+    GWANGJU("광주"),
+    DAEJEON("대전"),
+    ULSAN("울산"),
+    SEJONG("세종"),
+    GANGWON("강원"),
+    CHUNGBUK("충북"),
+    CHUNGNAM("충남"),
+    JEONBUK("전북"),
+    JEONNAM("전남"),
+    GYEONGBUK("경북"),
+    GYEONGNAM("경남"),
+    JEJU("제주");
+
+    private final String label;
+
+    Region(String label) {
+        this.label = label;
+    }
+
+    public String label() {
+        return label;
+    }
+
+    public static Region from(String value) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+
+        String normalized = value.trim();
+        for (Region region : values()) {
+            if (region.label.equals(normalized)) {
+                return region;
+            }
+        }
+
+        throw new CustomException(ErrorCode.LESSON_SEARCH_INVALID_REQUEST);
+    }
+}

--- a/src/main/java/baristation/lesson/payload/dto/CurriculumDTO.java
+++ b/src/main/java/baristation/lesson/payload/dto/CurriculumDTO.java
@@ -1,8 +1,9 @@
 package baristation.lesson.payload.dto;
 
 import baristation.lesson.domain.LessonCurriculum;
-import baristation.lesson.domain.LessonImages;
+import lombok.Builder;
 
+@Builder
 public record CurriculumDTO(
         String title,
         String summary,

--- a/src/main/java/baristation/lesson/payload/dto/CurriculumDTO.java
+++ b/src/main/java/baristation/lesson/payload/dto/CurriculumDTO.java
@@ -1,0 +1,18 @@
+package baristation.lesson.payload.dto;
+
+import baristation.lesson.domain.LessonCurriculum;
+import baristation.lesson.domain.LessonImages;
+
+public record CurriculumDTO(
+        String title,
+        String summary,
+        Integer sortOrder
+) {
+    public static CurriculumDTO from(LessonCurriculum lessonCurriculum) {
+        return new CurriculumDTO(
+                lessonCurriculum.getTitle(),
+                lessonCurriculum.getSummary(),
+                lessonCurriculum.getSortOrder()
+        );
+    }
+}

--- a/src/main/java/baristation/lesson/payload/dto/LessonDTO.java
+++ b/src/main/java/baristation/lesson/payload/dto/LessonDTO.java
@@ -1,9 +1,11 @@
 package baristation.lesson.payload.dto;
 
 import baristation.lesson.enums.DifficultyLevel;
+import lombok.Builder;
 
 import java.time.LocalDateTime;
 
+@Builder
 public record LessonDTO(
         Long lessonId,
         String lessonImageUrl,

--- a/src/main/java/baristation/lesson/payload/dto/LessonDTO.java
+++ b/src/main/java/baristation/lesson/payload/dto/LessonDTO.java
@@ -1,0 +1,20 @@
+package baristation.lesson.payload.dto;
+
+import baristation.lesson.enums.DifficultyLevel;
+
+import java.time.LocalDateTime;
+
+public record LessonDTO(
+        Long lessonId,
+        String lessonImageUrl,
+        String title,
+        String subTitle,
+        String hostName,
+        String hostProfileUrl,
+        String region,
+        String place,
+        LocalDateTime nextDate,
+        Integer price,
+        DifficultyLevel difficulty
+) {
+}

--- a/src/main/java/baristation/lesson/payload/dto/LessonDetailDTO.java
+++ b/src/main/java/baristation/lesson/payload/dto/LessonDetailDTO.java
@@ -1,0 +1,21 @@
+package baristation.lesson.payload.dto;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record LessonDetailDTO(
+        Long lessonId,
+        List<LessonImageDTO> lessonImages,
+        String title,
+        String hostName,
+        String hostProfileUrl,
+        List<String> careers,
+        String region,
+        String city,
+        String place,
+        List<LocalDateTime> schedules,
+        Integer duration,
+        List<CurriculumDTO> curriculum,
+        Integer price
+) {
+}

--- a/src/main/java/baristation/lesson/payload/dto/LessonImageDTO.java
+++ b/src/main/java/baristation/lesson/payload/dto/LessonImageDTO.java
@@ -1,0 +1,23 @@
+package baristation.lesson.payload.dto;
+
+import baristation.bean.domain.ProductImage;
+import baristation.bean.enums.ImageType;
+import baristation.bean.payload.dto.ProductImageDTO;
+import baristation.lesson.domain.Lesson;
+import baristation.lesson.domain.LessonImages;
+
+public record LessonImageDTO(
+        Long lessonImageId,
+        ImageType imageType,
+        String imageUrl,
+        Integer sortOrder
+) {
+    public static LessonImageDTO from(LessonImages lessonImage) {
+        return new LessonImageDTO(
+                lessonImage.getLessonImageId(),
+                lessonImage.getImageType(),
+                lessonImage.getImageUrl(),
+                lessonImage.getSortOrder()
+        );
+    }
+}

--- a/src/main/java/baristation/lesson/payload/dto/LessonImageDTO.java
+++ b/src/main/java/baristation/lesson/payload/dto/LessonImageDTO.java
@@ -1,23 +1,12 @@
 package baristation.lesson.payload.dto;
 
-import baristation.bean.domain.ProductImage;
 import baristation.bean.enums.ImageType;
-import baristation.bean.payload.dto.ProductImageDTO;
-import baristation.lesson.domain.Lesson;
-import baristation.lesson.domain.LessonImages;
+import lombok.Builder;
 
+@Builder
 public record LessonImageDTO(
         Long lessonImageId,
         ImageType imageType,
         String imageUrl,
         Integer sortOrder
-) {
-    public static LessonImageDTO from(LessonImages lessonImage) {
-        return new LessonImageDTO(
-                lessonImage.getLessonImageId(),
-                lessonImage.getImageType(),
-                lessonImage.getImageUrl(),
-                lessonImage.getSortOrder()
-        );
-    }
-}
+) { }

--- a/src/main/java/baristation/lesson/payload/request/LessonSearchRequest.java
+++ b/src/main/java/baristation/lesson/payload/request/LessonSearchRequest.java
@@ -1,0 +1,11 @@
+package baristation.lesson.payload.request;
+
+import baristation.lesson.enums.DifficultyLevel;
+
+public record LessonSearchRequest(
+        String keyword,
+
+        String region,
+        DifficultyLevel difficulty
+        ) {
+}

--- a/src/main/java/baristation/lesson/payload/request/LessonSearchRequest.java
+++ b/src/main/java/baristation/lesson/payload/request/LessonSearchRequest.java
@@ -4,7 +4,7 @@ import baristation.lesson.enums.DifficultyLevel;
 
 public record LessonSearchRequest(
         String keyword,
-
+        String category,
         String region,
         DifficultyLevel difficulty
         ) {

--- a/src/main/java/baristation/lesson/repository/LessonImageRepository.java
+++ b/src/main/java/baristation/lesson/repository/LessonImageRepository.java
@@ -1,7 +1,11 @@
 package baristation.lesson.repository;
 
+import baristation.bean.enums.ImageType;
 import baristation.lesson.domain.LessonImages;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface LessonImageRepository extends JpaRepository<LessonImages, Long> {
+    List<LessonImages> findByLesson_LessonIdInAndImageTypeOrderBySortOrderAsc(List<Long> lessonIds, ImageType imageType);
 }

--- a/src/main/java/baristation/lesson/repository/LessonRepository.java
+++ b/src/main/java/baristation/lesson/repository/LessonRepository.java
@@ -3,5 +3,5 @@ package baristation.lesson.repository;
 import baristation.lesson.domain.Lesson;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface LessonRepository extends JpaRepository<Lesson, Long> {
+public interface LessonRepository extends JpaRepository<Lesson, Long>, LessonRepositoryCustom {
 }

--- a/src/main/java/baristation/lesson/repository/LessonRepositoryCustom.java
+++ b/src/main/java/baristation/lesson/repository/LessonRepositoryCustom.java
@@ -1,0 +1,12 @@
+package baristation.lesson.repository;
+
+import baristation.lesson.domain.Lesson;
+import baristation.lesson.payload.request.LessonSearchRequest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface LessonRepositoryCustom {
+
+    // 검색 조건 + 페이징을 DB 레벨에서 처리하기 위한 커스텀 검색 메서드
+    Page<Lesson> searchLessonsWithFilters(LessonSearchRequest request, Pageable pageable);
+}

--- a/src/main/java/baristation/lesson/repository/LessonRepositoryImpl.java
+++ b/src/main/java/baristation/lesson/repository/LessonRepositoryImpl.java
@@ -2,6 +2,7 @@ package baristation.lesson.repository;
 
 import baristation.lesson.domain.Lesson;
 import baristation.lesson.enums.DifficultyLevel;
+import baristation.lesson.enums.LessonCategory;
 import baristation.lesson.enums.Region;
 import baristation.lesson.payload.request.LessonSearchRequest;
 import com.querydsl.core.types.OrderSpecifier;
@@ -28,6 +29,7 @@ public class LessonRepositoryImpl implements LessonRepositoryCustom {
     @Override
     public Page<Lesson> searchLessonsWithFilters(LessonSearchRequest request, Pageable pageable) {
         BooleanExpression keywordCondition = keywordContains(request == null ? null : request.keyword());
+        BooleanExpression categoryCondition = categoryEq(request == null ? null : request.category());
         BooleanExpression regionCondition = regionEq(request == null ? null : request.region());
         BooleanExpression difficultyCondition = difficultyEq(request == null ? null : request.difficulty());
 
@@ -36,6 +38,7 @@ public class LessonRepositoryImpl implements LessonRepositoryCustom {
                 .join(lesson.hostUser, user).fetchJoin()
                 .where(
                         keywordCondition,
+                        categoryCondition,
                         regionCondition,
                         difficultyCondition
                 )
@@ -50,6 +53,7 @@ public class LessonRepositoryImpl implements LessonRepositoryCustom {
                 .join(lesson.hostUser, user)
                 .where(
                         keywordCondition,
+                        categoryCondition,
                         regionCondition,
                         difficultyCondition
                 )
@@ -74,6 +78,16 @@ public class LessonRepositoryImpl implements LessonRepositoryCustom {
                 .or(lesson.address.containsIgnoreCase(normalized));
     }
 
+    // 카테고리가 정확히 일치하는 클래스를 찾는 조건을 만든다.
+    private BooleanExpression categoryEq(String category) {
+        LessonCategory normalizedCategory = LessonCategory.from(category);
+        if (normalizedCategory == null) {
+            return null;
+        }
+
+        return lesson.lessonCategory.eq(normalizedCategory);
+    }
+
     // 지역에 입력 지역명이 포함된 클래스를 찾는 조건을 만든다.
     private BooleanExpression regionEq(String region) {
         Region normalizedRegion = Region.from(region);
@@ -81,7 +95,9 @@ public class LessonRepositoryImpl implements LessonRepositoryCustom {
             return null;
         }
 
-        return lesson.region.eq(normalizedRegion.label());
+        // 프론트는 "제주" 같은 표시명을 보내지만, DB lessons.region에는 "JEJU" 같은 enum name이 저장되어 있다.
+        // 입력값은 label로 검증하고, 실제 DB 비교는 저장 형식에 맞춰 enum name으로 수행한다.
+        return lesson.region.eq(normalizedRegion.name());
     }
 
     // 난이도가 정확히 일치하는 클래스를 찾는 조건을 만든다.

--- a/src/main/java/baristation/lesson/repository/LessonRepositoryImpl.java
+++ b/src/main/java/baristation/lesson/repository/LessonRepositoryImpl.java
@@ -1,0 +1,96 @@
+package baristation.lesson.repository;
+
+import baristation.lesson.domain.Lesson;
+import baristation.lesson.enums.DifficultyLevel;
+import baristation.lesson.enums.Region;
+import baristation.lesson.payload.request.LessonSearchRequest;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+import static baristation.lesson.domain.QLesson.lesson;
+import static baristation.user.domain.QUser.user;
+
+@Repository
+@RequiredArgsConstructor
+public class LessonRepositoryImpl implements LessonRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    // 요청 필터와 페이징 조건을 QueryDSL 검색 쿼리로 변환해 클래스 목록과 전체 개수를 조회
+    @Override
+    public Page<Lesson> searchLessonsWithFilters(LessonSearchRequest request, Pageable pageable) {
+        BooleanExpression keywordCondition = keywordContains(request == null ? null : request.keyword());
+        BooleanExpression regionCondition = regionEq(request == null ? null : request.region());
+        BooleanExpression difficultyCondition = difficultyEq(request == null ? null : request.difficulty());
+
+        List<Lesson> content = queryFactory
+                .selectFrom(lesson)
+                .join(lesson.hostUser, user).fetchJoin()
+                .where(
+                        keywordCondition,
+                        regionCondition,
+                        difficultyCondition
+                )
+                .orderBy(defaultOrderSpecifiers())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        Long total = queryFactory
+                .select(lesson.count())
+                .from(lesson)
+                .join(lesson.hostUser, user)
+                .where(
+                        keywordCondition,
+                        regionCondition,
+                        difficultyCondition
+                )
+                .fetchOne();
+
+        return new PageImpl<>(content, pageable, total == null ? 0 : total);
+    }
+
+    // 제목, 부제목, 호스트 닉네임, 지역 정보에서 키워드가 포함된 클래스를 찾는 조건을 만든다.
+    private BooleanExpression keywordContains(String keyword) {
+        if (keyword == null || keyword.isBlank()) {
+            return null;
+        }
+
+        String normalized = keyword.trim();
+        return lesson.title.containsIgnoreCase(normalized)
+                .or(lesson.subtitle.containsIgnoreCase(normalized))
+                .or(user.nickname.containsIgnoreCase(normalized))
+                .or(lesson.region.containsIgnoreCase(normalized))
+                .or(lesson.city.containsIgnoreCase(normalized))
+                .or(lesson.place.containsIgnoreCase(normalized))
+                .or(lesson.address.containsIgnoreCase(normalized));
+    }
+
+    // 지역에 입력 지역명이 포함된 클래스를 찾는 조건을 만든다.
+    private BooleanExpression regionEq(String region) {
+        Region normalizedRegion = Region.from(region);
+        if (normalizedRegion == null) {
+            return null;
+        }
+
+        return lesson.region.eq(normalizedRegion.label());
+    }
+
+    // 난이도가 정확히 일치하는 클래스를 찾는 조건을 만든다.
+    private BooleanExpression difficultyEq(DifficultyLevel difficulty) {
+        return difficulty == null ? null : lesson.difficultyLevel.eq(difficulty);
+    }
+
+    // 최신순을 기본 정렬로 사용
+    private OrderSpecifier<?>[] defaultOrderSpecifiers() {
+        return new OrderSpecifier<?>[]{lesson.createdAt.desc().nullsLast(), lesson.lessonId.desc().nullsLast()};
+    }
+}

--- a/src/main/java/baristation/lesson/repository/LessonScheduleRepository.java
+++ b/src/main/java/baristation/lesson/repository/LessonScheduleRepository.java
@@ -1,7 +1,11 @@
 package baristation.lesson.repository;
 
 import baristation.lesson.domain.LessonSchedule;
+import baristation.lesson.enums.ScheduleStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface LessonScheduleRepository extends JpaRepository<LessonSchedule, Long> {
+    List<LessonSchedule> findByLesson_LessonIdInAndScheduleStatusOrderByLessonDateAsc(List<Long> lessonIds, ScheduleStatus scheduleStatus);
 }

--- a/src/main/java/baristation/lesson/repository/LessonScheduleRepository.java
+++ b/src/main/java/baristation/lesson/repository/LessonScheduleRepository.java
@@ -4,8 +4,13 @@ import baristation.lesson.domain.LessonSchedule;
 import baristation.lesson.enums.ScheduleStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 public interface LessonScheduleRepository extends JpaRepository<LessonSchedule, Long> {
-    List<LessonSchedule> findByLesson_LessonIdInAndScheduleStatusOrderByLessonDateAsc(List<Long> lessonIds, ScheduleStatus scheduleStatus);
+    List<LessonSchedule> findByLesson_LessonIdInAndScheduleStatusAndLessonDateGreaterThanEqualOrderByLessonDateAsc(
+            List<Long> lessonIds,
+            ScheduleStatus scheduleStatus,
+            LocalDateTime lessonDate
+    );
 }

--- a/src/main/java/baristation/lesson/service/LessonService.java
+++ b/src/main/java/baristation/lesson/service/LessonService.java
@@ -1,0 +1,19 @@
+package baristation.lesson.service;
+
+import baristation.common.payload.response.PageResponse;
+import baristation.lesson.payload.dto.LessonDTO;
+import baristation.lesson.payload.dto.LessonDetailDTO;
+import baristation.lesson.payload.request.LessonSearchRequest;
+import org.springframework.data.domain.Pageable;
+
+public interface LessonService {
+    /**
+     * 조건에 맞는 클래스 목록을 검색
+     */
+    PageResponse<LessonDTO> searchLessons(LessonSearchRequest request, Pageable pageable);
+
+    /**
+     * 클래스 단건 상세 조회
+     */
+    LessonDetailDTO getLessonDetail(Long lessonId);
+}

--- a/src/main/java/baristation/lesson/service/LessonServiceImpl.java
+++ b/src/main/java/baristation/lesson/service/LessonServiceImpl.java
@@ -21,6 +21,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -45,9 +46,6 @@ public class LessonServiceImpl implements LessonService {
 
         try {
             Page<Lesson> lessonPage = lessonRepository.searchLessonsWithFilters(request, pageable);
-            if (lessonPage.isEmpty()) {
-                return PageResponse.of(Page.empty(pageable));
-            }
 
             List<Long> lessonIds = lessonPage.getContent().stream()
                     .map(Lesson::getLessonId)
@@ -57,6 +55,8 @@ public class LessonServiceImpl implements LessonService {
             Map<Long, String> thumbImageByLessonId = getThumbImages(lessonIds);
             Map<Long, LessonSchedule> nextScheduleByLessonId = getNextSchedules(lessonIds);
 
+            // content가 비어 있어도 lessonPage.getTotalElements()는 그대로 유지
+            // 마지막 페이지를 넘어선 요청에서 검색 결과 총 개수가 0으로 바뀌는 문제를 막기 위함
             Page<LessonDTO> page = new PageImpl<>(
                     lessonPage.getContent().stream()
                             .map(lesson -> toLessonDto(
@@ -117,9 +117,12 @@ public class LessonServiceImpl implements LessonService {
             return Collections.emptyMap();
         }
 
-        return lessonScheduleRepository.findByLesson_LessonIdInAndScheduleStatusOrderByLessonDateAsc(
+        // "다음 일정"은 현재 시각 이후에 열려 있는 일정만 후보로 본다.
+        // 과거 OPEN 데이터가 남아 있어도 목록 응답의 nextDate가 과거로 내려가지 않게 막는다.
+        return lessonScheduleRepository.findByLesson_LessonIdInAndScheduleStatusAndLessonDateGreaterThanEqualOrderByLessonDateAsc(
                         lessonIds,
-                        ScheduleStatus.OPEN
+                        ScheduleStatus.OPEN,
+                        LocalDateTime.now()
                 )
                 .stream()
                 .collect(Collectors.toMap(

--- a/src/main/java/baristation/lesson/service/LessonServiceImpl.java
+++ b/src/main/java/baristation/lesson/service/LessonServiceImpl.java
@@ -117,8 +117,7 @@ public class LessonServiceImpl implements LessonService {
             return Collections.emptyMap();
         }
 
-        // "다음 일정"은 현재 시각 이후에 열려 있는 일정만 후보로 본다.
-        // 과거 OPEN 데이터가 남아 있어도 목록 응답의 nextDate가 과거로 내려가지 않게 막는다.
+        // 다음 일정은 현재 시각 이후에 열려 있는 일정만 후보로 본다.
         return lessonScheduleRepository.findByLesson_LessonIdInAndScheduleStatusAndLessonDateGreaterThanEqualOrderByLessonDateAsc(
                         lessonIds,
                         ScheduleStatus.OPEN,

--- a/src/main/java/baristation/lesson/service/LessonServiceImpl.java
+++ b/src/main/java/baristation/lesson/service/LessonServiceImpl.java
@@ -139,18 +139,19 @@ public class LessonServiceImpl implements LessonService {
             throw new CustomException(ErrorCode.LESSON_SEARCH_MAPPING_FAILED);
         }
 
-        return new LessonDTO(
-                lesson.getLessonId(),
-                thumbImageUrl,
-                lesson.getTitle(),
-                lesson.getSubtitle(),
-                lesson.getHostUser().getNickname(),
-                null,
-                lesson.getRegion(),
-                lesson.getPlace(),
-                nextSchedule == null ? null : nextSchedule.getLessonDate(),
-                nextSchedule == null ? null : nextSchedule.getPrice(),
-                lesson.getDifficultyLevel()
-        );
+        return LessonDTO.builder()
+                .lessonId(lesson.getLessonId())
+                .lessonImageUrl(thumbImageUrl)
+                .title(lesson.getTitle())
+                .subTitle(lesson.getSubtitle())
+                .hostName(lesson.getHostUser().getNickname())
+                // 현재 user profileUrl이 없어서 마이페이지 merge 후에 수정
+                .region(lesson.getRegion())
+                .place(lesson.getPlace())
+                .nextDate(nextSchedule == null ? null : nextSchedule.getLessonDate())
+                .price(nextSchedule == null ? null : nextSchedule.getPrice())
+                .difficulty(lesson.getDifficultyLevel())
+                .hostProfileUrl(null)
+                .build();
     }
 }

--- a/src/main/java/baristation/lesson/service/LessonServiceImpl.java
+++ b/src/main/java/baristation/lesson/service/LessonServiceImpl.java
@@ -1,0 +1,154 @@
+package baristation.lesson.service;
+
+import baristation.bean.enums.ImageType;
+import baristation.common.exception.CustomException;
+import baristation.common.exception.ErrorCode;
+import baristation.common.payload.response.PageResponse;
+import baristation.lesson.domain.Lesson;
+import baristation.lesson.domain.LessonImages;
+import baristation.lesson.domain.LessonSchedule;
+import baristation.lesson.enums.ScheduleStatus;
+import baristation.lesson.payload.dto.LessonDTO;
+import baristation.lesson.payload.dto.LessonDetailDTO;
+import baristation.lesson.payload.request.LessonSearchRequest;
+import baristation.lesson.repository.LessonImageRepository;
+import baristation.lesson.repository.LessonRepository;
+import baristation.lesson.repository.LessonScheduleRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class LessonServiceImpl implements LessonService {
+
+    private final LessonRepository lessonRepository;
+    private final LessonImageRepository lessonImageRepository;
+    private final LessonScheduleRepository lessonScheduleRepository;
+
+    /**
+     * 검색 조건에 맞는 클래스 목록을 조회하고, 썸네일 이미지와 가장 빠른 OPEN 일정을 함께 응답으로 조립
+     */
+    @Override
+    public PageResponse<LessonDTO> searchLessons(LessonSearchRequest request, Pageable pageable) {
+        validateSearchRequest(pageable);
+
+        try {
+            Page<Lesson> lessonPage = lessonRepository.searchLessonsWithFilters(request, pageable);
+            if (lessonPage.isEmpty()) {
+                return PageResponse.of(Page.empty(pageable));
+            }
+
+            List<Long> lessonIds = lessonPage.getContent().stream()
+                    .map(Lesson::getLessonId)
+                    .filter(Objects::nonNull)
+                    .toList();
+
+            Map<Long, String> thumbImageByLessonId = getThumbImages(lessonIds);
+            Map<Long, LessonSchedule> nextScheduleByLessonId = getNextSchedules(lessonIds);
+
+            Page<LessonDTO> page = new PageImpl<>(
+                    lessonPage.getContent().stream()
+                            .map(lesson -> toLessonDto(
+                                    lesson,
+                                    thumbImageByLessonId.get(lesson.getLessonId()),
+                                    nextScheduleByLessonId.get(lesson.getLessonId())
+                            ))
+                            .toList(),
+                    pageable,
+                    lessonPage.getTotalElements()
+            );
+
+            return PageResponse.of(page);
+        } catch (CustomException e) {
+            throw e;
+        } catch (RuntimeException e) {
+            throw new CustomException(ErrorCode.LESSON_SEARCH_FAILED);
+        }
+    }
+
+    // 추후 구현
+    @Override
+    public LessonDetailDTO getLessonDetail(Long lessonId) {
+        return null;
+    }
+
+    /**
+     * 검색에 필요한 페이징 값이 유효한지 확인
+     */
+    private void validateSearchRequest(Pageable pageable) {
+        if (pageable == null || pageable.getPageNumber() < 0 || pageable.getPageSize() < 1) {
+            throw new CustomException(ErrorCode.LESSON_SEARCH_INVALID_REQUEST);
+        }
+    }
+
+    /**
+     * 현재 페이지에 포함된 클래스들의 첫 번째 썸네일 이미지를 조회
+     */
+    private Map<Long, String> getThumbImages(List<Long> lessonIds) {
+        if (lessonIds.isEmpty()) {
+            return Collections.emptyMap();
+        }
+
+        return lessonImageRepository.findByLesson_LessonIdInAndImageTypeOrderBySortOrderAsc(lessonIds, ImageType.THUMB)
+                .stream()
+                .collect(Collectors.toMap(
+                        image -> image.getLesson().getLessonId(),
+                        LessonImages::getImageUrl,
+                        (first, second) -> first
+                ));
+    }
+
+    /**
+     * 현재 페이지에 포함된 클래스들의 가장 빠른 OPEN 일정을 조회
+     */
+    private Map<Long, LessonSchedule> getNextSchedules(List<Long> lessonIds) {
+        if (lessonIds.isEmpty()) {
+            return Collections.emptyMap();
+        }
+
+        return lessonScheduleRepository.findByLesson_LessonIdInAndScheduleStatusOrderByLessonDateAsc(
+                        lessonIds,
+                        ScheduleStatus.OPEN
+                )
+                .stream()
+                .collect(Collectors.toMap(
+                        schedule -> schedule.getLesson().getLessonId(),
+                        schedule -> schedule,
+                        (first, second) -> first
+                ));
+    }
+
+    /**
+     * 클래스 엔티티와 부가 조회 데이터를 목록 응답 DTO로 변환
+     */
+    private LessonDTO toLessonDto(Lesson lesson, String thumbImageUrl, LessonSchedule nextSchedule) {
+        if (lesson == null || lesson.getLessonId() == null || lesson.getHostUser() == null) {
+            throw new CustomException(ErrorCode.LESSON_SEARCH_MAPPING_FAILED);
+        }
+
+        return new LessonDTO(
+                lesson.getLessonId(),
+                thumbImageUrl,
+                lesson.getTitle(),
+                lesson.getSubtitle(),
+                lesson.getHostUser().getNickname(),
+                null,
+                lesson.getRegion(),
+                lesson.getPlace(),
+                nextSchedule == null ? null : nextSchedule.getLessonDate(),
+                nextSchedule == null ? null : nextSchedule.getPrice(),
+                lesson.getDifficultyLevel()
+        );
+    }
+}

--- a/src/main/java/baristation/user/domain/Career.java
+++ b/src/main/java/baristation/user/domain/Career.java
@@ -1,0 +1,20 @@
+package baristation.user.domain;
+
+import baristation.common.domain.BaseTimeEntity;
+import jakarta.persistence.*;
+
+@Entity
+@Table(name = "career")
+public class Career extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "career_id")
+    private Long careerId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User userId;
+
+    @Column(name = "title")
+    private String title;
+}

--- a/src/main/java/baristation/user/repository/CareerRepository.java
+++ b/src/main/java/baristation/user/repository/CareerRepository.java
@@ -1,0 +1,7 @@
+package baristation.user.repository;
+
+import baristation.user.domain.Career;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CareerRepository extends JpaRepository<Career, Long> {
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,115 @@
+spring:
+  config:
+    activate:
+      on-profile: local
+
+  application:
+    name: dripnote
+
+  datasource:
+    url: jdbc:mysql://localhost:3306/dripnote?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+    username: ssafy
+    password: ssafy
+    driver-class-name: com.mysql.cj.jdbc.Driver
+
+  security:
+    oauth2:
+      client:
+        registration:
+          google:
+            client-id: "356738567175-h8i8jdkfhcqsc7qmji4v27ijr87aq46b.apps.googleusercontent.com"
+            client-secret: "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"
+            scope: [ profile, email ]
+
+          kakao:
+            client-id: "97a16e014fbe91748922709abb6ded0c"
+            client-secret: "3WpE8zc8mHgkhJ5MHEAWaJGbPjhHpFZG"
+            client-authentication-method: client_secret_post
+            authorization-grant-type: authorization_code
+            redirect-uri: "{baseUrl}/login/oauth2/code/kakao"
+            scope: [ profile_nickname, account_email ]
+            client-name: Kakao
+
+          naver:
+            client-id: "HxFWTRJBoCfgHYJMSaH6"
+            client-secret: "9yLvuJgcgM"
+            authorization-grant-type: authorization_code
+            redirect-uri: "{baseUrl}/login/oauth2/code/naver"
+            client-name: Naver
+
+        provider:
+          kakao:
+            authorization-uri: https://kauth.kakao.com/oauth/authorize
+            token-uri: https://kauth.kakao.com/oauth/token
+            user-info-uri: https://kapi.kakao.com/v2/user/me
+            user-name-attribute: id
+
+          naver:
+            authorization-uri: https://nid.naver.com/oauth2.0/authorize
+            token-uri: https://nid.naver.com/oauth2.0/token
+            user-info-uri: https://openapi.naver.com/v1/nid/me
+            user-name-attribute: response
+
+  jpa:
+    hibernate:
+      ddl-auto: create
+    defer-datasource-initialization: true
+    open-in-view: false
+    properties:
+      hibernate:
+        jdbc:
+          time_zone: Asia/Seoul
+        format_sql: true
+
+  sql:
+    init:
+      mode: always
+
+  data:
+    redis:
+      host: localhost
+      port: 6379
+
+springdoc:
+  swagger-ui:
+    path: /swagger-custom-ui.html
+    url: /api-docs
+    groups-order: DESC
+    tags-sorter: alpha
+    operations-sorter: method
+    disable-swagger-default-url: true
+    display-request-duration: true
+
+  api-docs:
+    path: /api-docs
+
+  show-actuator: true
+  default-consumes-media-type: application/json
+  default-produces-media-type: application/json
+
+  paths-to-match:
+    - /api/**
+    - /oauth2/**
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info
+
+cloudflare:
+  r2:
+    account-id: "7c20a062aba088b31b67dbe49d04973a"
+    access-key-id: "3d3dc7c9fc5017ef292512e0bdf7c2cb"
+    secret-access-key: "762d12212d3d2ff2e060fdbc3a7cf0cd00eed33c634714031b443ef4859cc920"
+    bucket-name: "baristation-images"
+    public-base-url: "https://pub-c41a9919abd64864b940c181c034637e.r2.dev"
+
+jwt:
+  secret: "드립노트프로젝트의매우안전하고비밀스러운키값입니다하나둘셋야호"
+  access_expiration_time: 12h
+  refresh_expiration_time: 30d
+
+app:
+  frontend:
+    base-url: "https://baristation.vercel.app"


### PR DESCRIPTION
## #️⃣연관된 이슈

> #56 

## 📝작업 내용

> 클래스 목록 조회 기능을 구현하였습니다.
> 아래 이미지는 전체 조회 입니다.
<img width="892" height="935" alt="image" src="https://github.com/user-attachments/assets/152da0ab-f072-4c09-9647-e6e4050adaec" />

> 아래 이미지는 검색 조회 기능입니다.
<img width="966" height="862" alt="image" src="https://github.com/user-attachments/assets/d57b9714-880e-4e0f-a3a6-fb0c5cdea812" />


## 논의하고 싶은 부분(선택)

> region과 lessonCategory를 enum형태로 바꿨는데 프론트에서 "서울" 및 "취미" 이런 식으로 들어오면 "SEOUL", "HOBBY" 이런 식으로 변환해서 사용하고 있습니다. 더 좋은 방법이 있으면 알려주세요

## 🫡 참고사항
