### PR TITLE
refactor: toLessonDto의 hostProfileUrl 수정

### DIFF
--- a/src/main/java/baristation/lesson/service/LessonServiceImpl.java
+++ b/src/main/java/baristation/lesson/service/LessonServiceImpl.java
@@ -265,7 +265,7 @@ public class LessonServiceImpl implements LessonService {
                 .nextDate(nextSchedule == null ? null : nextSchedule.getLessonDate())
                 .price(nextSchedule == null ? null : nextSchedule.getPrice())
                 .difficulty(lesson.getDifficultyLevel())
-                .hostProfileUrl(lesson.getHostUser().getProfileImageUrl())
+                .hostProfileUrl(imageUrlResolver.toPublicUrl(lesson.getHostUser().getProfileImageUrl()))
                 .build();
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #72 

## 📝작업 내용

> 클래스 목록 api에 바리스타 프로필 이미지 주소를 변경하였습니다.
<img width="824" height="503" alt="image" src="https://github.com/user-attachments/assets/c021bfa1-1eb7-4fc7-aa80-36d3b3b4f243" />
